### PR TITLE
add: 마을/다락방 출석 편집 기능 및 출석 API 보안 강화

### DIFF
--- a/client/src/app/admin/soon/attendance/AttendCell.tsx
+++ b/client/src/app/admin/soon/attendance/AttendCell.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import { useState } from "react"
 import {
   Box,

--- a/client/src/app/admin/soon/attendance/AttendCell.tsx
+++ b/client/src/app/admin/soon/attendance/AttendCell.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { useState } from "react"
 import {
   Box,

--- a/client/src/app/admin/soon/attendance/AttendCell.tsx
+++ b/client/src/app/admin/soon/attendance/AttendCell.tsx
@@ -1,68 +1,154 @@
-import { Box } from "@mui/material"
+import { useState } from "react"
+import {
+  Box,
+  Popover,
+  Select,
+  MenuItem,
+  TextField,
+  Button,
+  Stack,
+  Typography,
+} from "@mui/material"
 import { AttendData } from "@server/entity/attendData"
 import { AttendStatus } from "@server/entity/types"
+import CheckCircleIcon from "@mui/icons-material/CheckCircle"
+import CancelIcon from "@mui/icons-material/Cancel"
+import HelpIcon from "@mui/icons-material/Help"
 
 interface AttendCellProps {
   attendData: AttendData | undefined
+  editable?: boolean
+  onSave?: (status: AttendStatus, memo: string) => Promise<void> | void
 }
 
-export default function AttendCell({ attendData }: AttendCellProps) {
-  if (!attendData) {
-    return (
-      <Box
-        width="100%"
-        height="100%"
-        textAlign="center"
-        alignContent="center"
-        justifyContent="center"
-      >
-        -
-      </Box>
-    )
+export default function AttendCell({
+  attendData,
+  editable = false,
+  onSave,
+}: AttendCellProps) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const [status, setStatus] = useState<AttendStatus>(AttendStatus.ATTEND)
+  const [memo, setMemo] = useState("")
+  const [saving, setSaving] = useState(false)
+
+  function handleOpen(e: React.MouseEvent<HTMLElement>) {
+    if (!editable) return
+    setStatus(attendData?.isAttend ?? AttendStatus.ATTEND)
+    setMemo(attendData?.memo ?? "")
+    setAnchorEl(e.currentTarget)
   }
 
-  if (attendData.isAttend === AttendStatus.ATTEND) {
-    return (
-      <Box
-        width="100%"
-        height="100%"
-        textAlign="center"
-        alignContent="center"
-        justifyContent="center"
-        style={{ backgroundColor: "rgb(184, 248,93)" }}
-      >
-        출석
-      </Box>
-    )
+  async function handleSave() {
+    if (!onSave) return
+    setSaving(true)
+    try {
+      await onSave(status, memo)
+      setAnchorEl(null)
+    } finally {
+      setSaving(false)
+    }
   }
 
-  if (attendData.isAttend === AttendStatus.ABSENT) {
-    return (
-      <Box
-        width="100%"
-        height="100%"
-        textAlign="center"
-        alignContent="center"
-        justifyContent="center"
-        style={{ backgroundColor: "rgb(240, 148, 128)" }}
-      >
-        {attendData.memo}
-      </Box>
-    )
+  let bg = "transparent"
+  let label: React.ReactNode = "-"
+
+  if (attendData?.isAttend === AttendStatus.ATTEND) {
+    bg = "rgb(184, 248, 93)"
+    label = "출석"
+  } else if (attendData?.isAttend === AttendStatus.ABSENT) {
+    bg = "rgb(240, 148, 128)"
+    label = attendData.memo || "결석"
+  } else if (attendData?.isAttend === AttendStatus.ETC) {
+    bg = "rgb(253, 241, 113)"
+    label = attendData.memo || "기타"
   }
 
-  if (attendData.isAttend === AttendStatus.ETC) {
-    return (
+  return (
+    <>
       <Box
-        width="100%"
-        height="100%"
-        textAlign="center"
-        alignContent="center"
-        justifyContent="center"
-        style={{ backgroundColor: "rgb(253,241,113)" }}
+        onClick={handleOpen}
+        sx={{
+          width: "100%",
+          height: "100%",
+          textAlign: "center",
+          alignContent: "center",
+          justifyContent: "center",
+          cursor: editable ? "pointer" : "default",
+          fontSize: "0.85rem",
+          bgcolor: bg,
+          transition: "opacity 0.15s",
+          "&:hover": editable ? { opacity: 0.72 } : {},
+        }}
       >
-        {attendData.memo}
+        {label}
       </Box>
-    )
-  }
+      {editable && (
+        <Popover
+          open={Boolean(anchorEl)}
+          anchorEl={anchorEl}
+          onClose={() => {
+            if (!saving) setAnchorEl(null)
+          }}
+          anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+          transformOrigin={{ vertical: "top", horizontal: "center" }}
+        >
+          <Stack p={2} spacing={1.5} minWidth={220}>
+            <Typography variant="caption" color="text.secondary">
+              출석 수정
+            </Typography>
+            <Select
+              size="small"
+              value={status}
+              onChange={(e) => setStatus(e.target.value as AttendStatus)}
+            >
+              <MenuItem value={AttendStatus.ATTEND}>
+                <Stack direction="row" alignItems="center" spacing={1}>
+                  <CheckCircleIcon sx={{ color: "#4caf50", fontSize: 16 }} />
+                  <span>출석</span>
+                </Stack>
+              </MenuItem>
+              <MenuItem value={AttendStatus.ABSENT}>
+                <Stack direction="row" alignItems="center" spacing={1}>
+                  <CancelIcon sx={{ color: "#f44336", fontSize: 16 }} />
+                  <span>결석</span>
+                </Stack>
+              </MenuItem>
+              <MenuItem value={AttendStatus.ETC}>
+                <Stack direction="row" alignItems="center" spacing={1}>
+                  <HelpIcon sx={{ color: "#ff9800", fontSize: 16 }} />
+                  <span>기타</span>
+                </Stack>
+              </MenuItem>
+            </Select>
+            {status !== AttendStatus.ATTEND && (
+              <TextField
+                size="small"
+                placeholder="사유"
+                value={memo}
+                onChange={(e) => setMemo(e.target.value)}
+                autoFocus
+              />
+            )}
+            <Stack direction="row" spacing={1} justifyContent="flex-end">
+              <Button
+                size="small"
+                onClick={() => setAnchorEl(null)}
+                disabled={saving}
+              >
+                취소
+              </Button>
+              <Button
+                size="small"
+                variant="contained"
+                onClick={handleSave}
+                disabled={saving}
+              >
+                {saving ? "저장 중…" : "저장"}
+              </Button>
+            </Stack>
+          </Stack>
+        </Popover>
+      )}
+    </>
+  )
 }

--- a/client/src/app/admin/soon/attendance/AttendanceTable.tsx
+++ b/client/src/app/admin/soon/attendance/AttendanceTable.tsx
@@ -1,4 +1,12 @@
-import { Box, Stack, Typography, Paper, Chip } from "@mui/material"
+import {
+  Box,
+  Stack,
+  Typography,
+  Paper,
+  Chip,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material"
 import { User } from "@server/entity/user"
 import { AttendData } from "@server/entity/attendData"
 import { WorshipSchedule } from "@server/entity/worshipSchedule"
@@ -34,7 +42,9 @@ export default function AttendanceTable({
   editable = false,
   onSaveCell,
 }: AttendanceTableProps) {
-  const isMobile = global.innerWidth < 600
+  const theme = useTheme()
+  // SSR-safe: 서버 렌더 시엔 false, 마운트 후 실제 window 크기로 재계산
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"))
   return (
     <Box sx={{ p: 2 }}>
       {/* 출석 테이블 제목 */}

--- a/client/src/app/admin/soon/attendance/AttendanceTable.tsx
+++ b/client/src/app/admin/soon/attendance/AttendanceTable.tsx
@@ -2,6 +2,7 @@ import { Box, Stack, Typography, Paper, Chip } from "@mui/material"
 import { User } from "@server/entity/user"
 import { AttendData } from "@server/entity/attendData"
 import { WorshipSchedule } from "@server/entity/worshipSchedule"
+import { AttendStatus } from "@server/entity/types"
 import AttendCell from "./AttendCell"
 import StarIcon from "@mui/icons-material/Star"
 import StarBorderIcon from "@mui/icons-material/StarBorder"
@@ -15,6 +16,13 @@ interface AttendanceTableProps {
     attendDataList: AttendData[],
     worshipScheduleId: number,
   ) => { count: number; attend: number }
+  editable?: boolean
+  onSaveCell?: (
+    userId: string,
+    worshipScheduleId: number,
+    status: AttendStatus,
+    memo: string,
+  ) => Promise<void>
 }
 
 export default function AttendanceTable({
@@ -23,6 +31,8 @@ export default function AttendanceTable({
   worshipScheduleMapList,
   leaders,
   getAttendUserCount,
+  editable = false,
+  onSaveCell,
 }: AttendanceTableProps) {
   const isMobile = global.innerWidth < 600
   return (
@@ -197,7 +207,16 @@ export default function AttendanceTable({
                       justifyContent: "center",
                     }}
                   >
-                    <AttendCell attendData={attendData} />
+                    <AttendCell
+                      attendData={attendData}
+                      editable={editable}
+                      onSave={
+                        onSaveCell
+                          ? (status, memo) =>
+                              onSaveCell(user.id, worshipSchedule.id, status, memo)
+                          : undefined
+                      }
+                    />
                   </Box>
                 )
               })}

--- a/client/src/app/admin/soon/attendance/AttendanceTable.tsx
+++ b/client/src/app/admin/soon/attendance/AttendanceTable.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import {
   Box,
   Stack,

--- a/client/src/app/admin/soon/attendance/AttendanceTable.tsx
+++ b/client/src/app/admin/soon/attendance/AttendanceTable.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import {
   Box,
   Stack,
@@ -45,7 +43,7 @@ export default function AttendanceTable({
   onSaveCell,
 }: AttendanceTableProps) {
   const theme = useTheme()
-  // SSR-safe: 서버 렌더 시엔 false, 마운트 후 실제 window 크기로 재계산
+  // SSG: 빌드 시엔 false, 마운트 후 실제 window 크기로 재계산
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"))
   return (
     <Box sx={{ p: 2 }}>
@@ -205,6 +203,10 @@ export default function AttendanceTable({
                     data.user.id === user.id &&
                     data.worshipSchedule.id === worshipSchedule.id,
                 )
+                const handleSave = onSaveCell
+                  ? (status: AttendStatus, memo: string) =>
+                      onSaveCell(user.id, worshipSchedule.id, status, memo)
+                  : undefined
                 return (
                   <Box
                     key={worshipSchedule.id}
@@ -222,12 +224,7 @@ export default function AttendanceTable({
                     <AttendCell
                       attendData={attendData}
                       editable={editable}
-                      onSave={
-                        onSaveCell
-                          ? (status, memo) =>
-                              onSaveCell(user.id, worshipSchedule.id, status, memo)
-                          : undefined
-                      }
+                      onSave={handleSave}
                     />
                   </Box>
                 )

--- a/client/src/app/admin/soon/attendance/EditTab.tsx
+++ b/client/src/app/admin/soon/attendance/EditTab.tsx
@@ -35,7 +35,11 @@ import { Community } from "@server/entity/community"
 import { User } from "@server/entity/user"
 import { WorshipSchedule } from "@server/entity/worshipSchedule"
 import { worshipKr } from "@/util/worship"
-import { toAttendanceErrorMessage } from "@/util/attendanceError"
+import {
+  BulkAttendanceResponse,
+  toAttendanceErrorMessage,
+  toBulkResultMessage,
+} from "@/util/attendanceError"
 import { useNotification } from "@/hooks/useNotification"
 
 type StatusFilter = "all" | "unrecorded" | "ATTEND" | "ABSENT" | "ETC"
@@ -337,26 +341,19 @@ export default function EditTab() {
     let successfulIds: string[] = []
     let firstFailureMessage = ""
     try {
-      const response = await axios.post<{
-        results: Array<{
-          index: number
-          userId: string
-          status: "ok" | "forbidden" | "invalid" | "error"
-          error?: string
-        }>
-      }>("/admin/soon/update-attendance-bulk", {
-        worshipScheduleId: selectedScheduleId,
-        items: ids.map((userId) => ({ userId, isAttend: status, memo })),
-      })
+      const response = await axios.post<BulkAttendanceResponse>(
+        "/admin/soon/update-attendance-bulk",
+        {
+          worshipScheduleId: selectedScheduleId,
+          items: ids.map((userId) => ({ userId, isAttend: status, memo })),
+        },
+      )
       successfulIds = response.data.results
         .filter((r) => r.status === "ok")
         .map((r) => r.userId)
       const firstFail = response.data.results.find((r) => r.status !== "ok")
       if (firstFail) {
-        firstFailureMessage =
-          firstFail.status === "forbidden"
-            ? "해당 유저의 출석을 편집할 권한이 없습니다."
-            : firstFail.error || "저장에 실패했습니다."
+        firstFailureMessage = toBulkResultMessage(firstFail)
       }
     } catch (e) {
       firstFailureMessage = toAttendanceErrorMessage(e)
@@ -431,20 +428,16 @@ export default function EditTab() {
 
     let successIds: string[] = []
     try {
-      const response = await axios.post<{
-        results: Array<{
-          index: number
-          userId: string
-          status: "ok" | "forbidden" | "invalid" | "error"
-          error?: string
-        }>
-      }>("/admin/soon/update-attendance-bulk", {
-        worshipScheduleId: action.scheduleId,
-        items: restorable.map((userId) => {
-          const prev = action.previousStates.get(userId)!
-          return { userId, isAttend: prev.status, memo: prev.memo }
-        }),
-      })
+      const response = await axios.post<BulkAttendanceResponse>(
+        "/admin/soon/update-attendance-bulk",
+        {
+          worshipScheduleId: action.scheduleId,
+          items: restorable.map((userId) => {
+            const prev = action.previousStates.get(userId)!
+            return { userId, isAttend: prev.status, memo: prev.memo }
+          }),
+        },
+      )
       successIds = response.data.results
         .filter((r) => r.status === "ok")
         .map((r) => r.userId)

--- a/client/src/app/admin/soon/attendance/EditTab.tsx
+++ b/client/src/app/admin/soon/attendance/EditTab.tsx
@@ -334,26 +334,33 @@ export default function EditTab() {
     })
 
     setSaving(true)
-    const BULK_SAVE_BATCH_SIZE = 10
-    const results: PromiseSettledResult<unknown>[] = []
-    for (let i = 0; i < ids.length; i += BULK_SAVE_BATCH_SIZE) {
-      const batchIds = ids.slice(i, i + BULK_SAVE_BATCH_SIZE)
-      const batchResults = await Promise.allSettled(
-        batchIds.map((userId) =>
-          axios.post("/admin/soon/update-attendance", {
-            userId,
-            worshipScheduleId: selectedScheduleId,
-            isAttend: status,
-            memo,
-          }),
-        ),
-      )
-      results.push(...batchResults)
+    let successfulIds: string[] = []
+    let firstFailureMessage = ""
+    try {
+      const response = await axios.post<{
+        results: Array<{
+          index: number
+          userId: string
+          status: "ok" | "forbidden" | "invalid" | "error"
+          error?: string
+        }>
+      }>("/admin/soon/update-attendance-bulk", {
+        worshipScheduleId: selectedScheduleId,
+        items: ids.map((userId) => ({ userId, isAttend: status, memo })),
+      })
+      successfulIds = response.data.results
+        .filter((r) => r.status === "ok")
+        .map((r) => r.userId)
+      const firstFail = response.data.results.find((r) => r.status !== "ok")
+      if (firstFail) {
+        firstFailureMessage =
+          firstFail.status === "forbidden"
+            ? "해당 유저의 출석을 편집할 권한이 없습니다."
+            : firstFail.error || "저장에 실패했습니다."
+      }
+    } catch (e) {
+      firstFailureMessage = toAttendanceErrorMessage(e)
     }
-    const successfulIds: string[] = []
-    ids.forEach((id, i) => {
-      if (results[i].status === "fulfilled") successfulIds.push(id)
-    })
 
     setAttendData((prev) => {
       const map = new Map(prev.map((d) => [d.user.id, d]))
@@ -379,14 +386,10 @@ export default function EditTab() {
     setSaving(false)
     const failed = ids.length - successfulIds.length
     if (failed > 0) {
-      const firstFailure = results.find(
-        (r) => r.status === "rejected",
-      ) as PromiseRejectedResult | undefined
-      const reason = firstFailure
-        ? toAttendanceErrorMessage(firstFailure.reason)
-        : ""
       error(
-        reason ? `${failed}건 저장 실패 — ${reason}` : `${failed}건 저장 실패`,
+        firstFailureMessage
+          ? `${failed}건 저장 실패 — ${firstFailureMessage}`
+          : `${failed}건 저장 실패`,
       )
     }
 
@@ -426,20 +429,28 @@ export default function EditTab() {
       return
     }
 
-    const results = await Promise.allSettled(
-      restorable.map((userId) => {
-        const prev = action.previousStates.get(userId)!
-        return axios.post("/admin/soon/update-attendance", {
-          userId,
-          worshipScheduleId: action.scheduleId,
-          isAttend: prev.status,
-          memo: prev.memo,
-        })
-      }),
-    )
-    const successIds = restorable.filter(
-      (_, i) => results[i].status === "fulfilled",
-    )
+    let successIds: string[] = []
+    try {
+      const response = await axios.post<{
+        results: Array<{
+          index: number
+          userId: string
+          status: "ok" | "forbidden" | "invalid" | "error"
+          error?: string
+        }>
+      }>("/admin/soon/update-attendance-bulk", {
+        worshipScheduleId: action.scheduleId,
+        items: restorable.map((userId) => {
+          const prev = action.previousStates.get(userId)!
+          return { userId, isAttend: prev.status, memo: prev.memo }
+        }),
+      })
+      successIds = response.data.results
+        .filter((r) => r.status === "ok")
+        .map((r) => r.userId)
+    } catch {
+      // 네트워크 에러 등: successIds 빈 배열 유지
+    }
 
     // 로컬 상태 복원
     setAttendData((prev) => {

--- a/client/src/app/admin/soon/attendance/EditTab.tsx
+++ b/client/src/app/admin/soon/attendance/EditTab.tsx
@@ -5,10 +5,6 @@ import {
   Box,
   Stack,
   Typography,
-  Select,
-  MenuItem,
-  FormControl,
-  InputLabel,
   TextField,
   Checkbox,
   Button,
@@ -39,6 +35,7 @@ import { Community } from "@server/entity/community"
 import { User } from "@server/entity/user"
 import { WorshipSchedule } from "@server/entity/worshipSchedule"
 import { worshipKr } from "@/util/worship"
+import { toAttendanceErrorMessage } from "@/util/attendanceError"
 import { useNotification } from "@/hooks/useNotification"
 
 type StatusFilter = "all" | "unrecorded" | "ATTEND" | "ABSENT" | "ETC"
@@ -337,16 +334,22 @@ export default function EditTab() {
     })
 
     setSaving(true)
-    const results = await Promise.allSettled(
-      ids.map((userId) =>
-        axios.post("/admin/soon/update-attendance", {
-          userId,
-          worshipScheduleId: selectedScheduleId,
-          isAttend: status,
-          memo,
-        }),
-      ),
-    )
+    const BULK_SAVE_BATCH_SIZE = 10
+    const results: PromiseSettledResult<unknown>[] = []
+    for (let i = 0; i < ids.length; i += BULK_SAVE_BATCH_SIZE) {
+      const batchIds = ids.slice(i, i + BULK_SAVE_BATCH_SIZE)
+      const batchResults = await Promise.allSettled(
+        batchIds.map((userId) =>
+          axios.post("/admin/soon/update-attendance", {
+            userId,
+            worshipScheduleId: selectedScheduleId,
+            isAttend: status,
+            memo,
+          }),
+        ),
+      )
+      results.push(...batchResults)
+    }
     const successfulIds: string[] = []
     ids.forEach((id, i) => {
       if (results[i].status === "fulfilled") successfulIds.push(id)
@@ -376,7 +379,15 @@ export default function EditTab() {
     setSaving(false)
     const failed = ids.length - successfulIds.length
     if (failed > 0) {
-      error(`${failed}건 저장 실패`)
+      const firstFailure = results.find(
+        (r) => r.status === "rejected",
+      ) as PromiseRejectedResult | undefined
+      const reason = firstFailure
+        ? toAttendanceErrorMessage(firstFailure.reason)
+        : ""
+      error(
+        reason ? `${failed}건 저장 실패 — ${reason}` : `${failed}건 저장 실패`,
+      )
     }
 
     // Phase 3: Undo 액션 준비 (성공한 것만)

--- a/client/src/app/admin/soon/attendance/EditTab.tsx
+++ b/client/src/app/admin/soon/attendance/EditTab.tsx
@@ -453,7 +453,6 @@ export default function EditTab() {
   }
 
   function statusChip(status: StatusFilter, memo?: string) {
-    // chip 공통 style — 긴 memo는 말줄임 처리
     const base = {
       fontWeight: 600,
       maxWidth: { xs: 140, sm: 200, md: 260 },
@@ -1075,6 +1074,12 @@ export default function EditTab() {
   )
 }
 
+function statusLabel(status: AttendStatus) {
+  if (status === AttendStatus.ATTEND) return "출석"
+  if (status === AttendStatus.ABSENT) return "결석"
+  return "기타"
+}
+
 /* --- 하위 컴포넌트 --- */
 
 function ColumnBox({
@@ -1151,10 +1156,4 @@ function EmptyState({ children }: { children: React.ReactNode }) {
       <Typography variant="body2">{children}</Typography>
     </Box>
   )
-}
-
-function statusLabel(status: AttendStatus) {
-  if (status === AttendStatus.ATTEND) return "출석"
-  if (status === AttendStatus.ABSENT) return "결석"
-  return "기타"
 }

--- a/client/src/app/admin/soon/attendance/EditTab.tsx
+++ b/client/src/app/admin/soon/attendance/EditTab.tsx
@@ -29,6 +29,7 @@ import ArrowBackIcon from "@mui/icons-material/ArrowBack"
 import CheckCircleIcon from "@mui/icons-material/CheckCircle"
 import CancelIcon from "@mui/icons-material/Cancel"
 import HelpIcon from "@mui/icons-material/Help"
+import CloseIcon from "@mui/icons-material/Close"
 
 import axios from "@/config/axios"
 import { get } from "@/config/api"
@@ -74,6 +75,8 @@ export default function EditTab() {
 
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down("md"))
+  // bulk 버튼 라벨 숨김 기준 — 600px 미만에선 아이콘만
+  const isNarrow = useMediaQuery(theme.breakpoints.down("sm"))
 
   // 초기 로드
   useEffect(() => {
@@ -450,30 +453,48 @@ export default function EditTab() {
   }
 
   function statusChip(status: StatusFilter, memo?: string) {
+    // chip 공통 style — 긴 memo는 말줄임 처리
+    const base = {
+      fontWeight: 600,
+      maxWidth: { xs: 140, sm: 200, md: 260 },
+      // MUI Chip 기본 label엔 이미 ellipsis가 걸려있지만, 명시적으로 한 번 더
+      "& .MuiChip-label": {
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+      },
+    }
     if (status === "ATTEND")
       return (
         <Chip
           size="small"
           label="출석"
-          sx={{ bgcolor: "rgb(184, 248, 93)", fontWeight: 600 }}
+          title="출석"
+          sx={{ ...base, bgcolor: "rgb(184, 248, 93)" }}
         />
       )
-    if (status === "ABSENT")
+    if (status === "ABSENT") {
+      const full = memo ? `결석 · ${memo}` : "결석"
       return (
         <Chip
           size="small"
-          label={memo ? `결석 · ${memo}` : "결석"}
-          sx={{ bgcolor: "rgb(240, 148, 128)", fontWeight: 600 }}
+          label={full}
+          title={full}
+          sx={{ ...base, bgcolor: "rgb(240, 148, 128)" }}
         />
       )
-    if (status === "ETC")
+    }
+    if (status === "ETC") {
+      const full = memo ? `기타 · ${memo}` : "기타"
       return (
         <Chip
           size="small"
-          label={memo ? `기타 · ${memo}` : "기타"}
-          sx={{ bgcolor: "rgb(253, 241, 113)", fontWeight: 600 }}
+          label={full}
+          title={full}
+          sx={{ ...base, bgcolor: "rgb(253, 241, 113)" }}
         />
       )
+    }
     return null
   }
 
@@ -495,31 +516,79 @@ export default function EditTab() {
   }
 
   return (
-    <Box sx={{ p: 2, pb: 12 }}>
-      {/* 예배 선택 */}
+    <Box
+      sx={{
+        p: 2,
+        // bulk bar 공간 + iPhone 홈 인디케이터 영역만큼 여유
+        pb: "calc(96px + env(safe-area-inset-bottom, 0px))",
+      }}
+    >
+      {/* 컨트롤 3종을 sticky 래퍼로 묶어 리스트 스크롤 시에도 상단 고정 */}
+      <Box
+        sx={{
+          position: "sticky",
+          top: 48, // Tabs 높이만큼 내려옴
+          zIndex: 5,
+          bgcolor: "#f5f5f5", // 외부 배경과 동일해서 리스트가 비쳐 보이지 않게
+          mx: -2, // 외부 p:2 상쇄
+          px: 2, // 다시 적용
+          pt: 2,
+          pb: 0.5,
+          mb: 1,
+          // 하단에 살짝 그림자 → 스크롤되어 띄워진 상태임을 암시
+          boxShadow: "0 2px 8px -4px rgba(0,0,0,0.12)",
+        }}
+      >
+      {/* 예배 선택 — 모바일: OS 네이티브 picker (iOS 휠, Android 다이얼로그) */}
       <Paper sx={{ p: 2, mb: 2 }}>
-        <FormControl fullWidth size="small">
-          <InputLabel>예배</InputLabel>
-          <Select
-            value={selectedScheduleId}
-            label="예배"
-            onChange={(e) => setSelectedScheduleId(e.target.value as number)}
-          >
-            {schedules.map((s) => (
-              <MenuItem key={s.id} value={s.id}>
-                {s.date} · {worshipKr(s.kind)}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+        <TextField
+          select
+          SelectProps={{ native: true }}
+          value={selectedScheduleId}
+          label="예배"
+          fullWidth
+          size="small"
+          onChange={(e) =>
+            setSelectedScheduleId(Number(e.target.value) || "")
+          }
+          InputLabelProps={{ shrink: true }}
+        >
+          {schedules.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.date} · {worshipKr(s.kind)}
+            </option>
+          ))}
+        </TextField>
       </Paper>
 
-      {/* 상태 필터 */}
+      {/* 상태 필터 — 모바일 친화적 가로 스크롤 */}
       <Paper sx={{ p: 2, mb: 2 }}>
         <Typography variant="caption" color="text.secondary">
           상태별 필터
         </Typography>
-        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap mt={1}>
+        <Box
+          sx={{
+            display: "flex",
+            gap: 1,
+            mt: 1,
+            overflowX: "auto",
+            overflowY: "hidden",
+            // 각 chip이 줄어들지 않음
+            "& > *": { flexShrink: 0 },
+            // 스크롤바 숨김 (가독성)
+            "&::-webkit-scrollbar": { display: "none" },
+            scrollbarWidth: "none",
+            // iOS 모멘텀 스크롤
+            WebkitOverflowScrolling: "touch",
+            // 오른쪽 가장자리 페이드 힌트 (스크롤 가능 암시)
+            WebkitMaskImage:
+              "linear-gradient(to right, black calc(100% - 24px), transparent)",
+            maskImage:
+              "linear-gradient(to right, black calc(100% - 24px), transparent)",
+            pr: 3, // 페이드 영역 너비만큼 여유
+            pb: 0.5,
+          }}
+        >
           {(
             [
               { k: "all", label: "전체", count: counts.all },
@@ -538,7 +607,7 @@ export default function EditTab() {
               disabled={k !== "all" && count === 0}
             />
           ))}
-        </Stack>
+        </Box>
       </Paper>
 
       {/* 검색 */}
@@ -551,6 +620,8 @@ export default function EditTab() {
           onChange={(e) => setSearchText(e.target.value)}
         />
       </Paper>
+      </Box>
+      {/* ↑ sticky 래퍼 종료 */}
 
       {/* 3-column 리스트 */}
       <Paper sx={{ p: 2 }}>
@@ -895,7 +966,13 @@ export default function EditTab() {
           setUndoAction(null)
         }}
         anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
-        sx={{ mb: checkedIds.size > 0 ? 10 : 2 }}
+        sx={{
+          // bulk bar 위로 / 없으면 최소 여백. 모두 safe-area inset 추가
+          mb:
+            checkedIds.size > 0
+              ? "calc(80px + env(safe-area-inset-bottom, 0px))"
+              : "calc(16px + env(safe-area-inset-bottom, 0px))",
+        }}
         message={
           undoAction
             ? `${undoAction.userIds.length}명에게 '${statusLabel(
@@ -919,7 +996,10 @@ export default function EditTab() {
             bottom: 0,
             left: 0,
             right: 0,
-            p: 1.5,
+            pt: 1.5,
+            px: 1.5,
+            // 하단 padding에 iPhone 홈 인디케이터 인셋 포함
+            pb: "calc(12px + env(safe-area-inset-bottom, 0px))",
             zIndex: 100,
             borderTop: "2px solid #1976d2",
           }}
@@ -944,40 +1024,48 @@ export default function EditTab() {
               <Button
                 variant="contained"
                 color="success"
-                startIcon={<CheckCircleIcon />}
+                startIcon={isNarrow ? undefined : <CheckCircleIcon />}
                 onClick={() => handleBulkSave(AttendStatus.ATTEND)}
                 disabled={saving}
                 size="small"
+                title="출석"
+                sx={{ minWidth: { xs: 44, sm: "auto" }, px: { xs: 1, sm: 2 } }}
               >
-                출석
+                {isNarrow ? <CheckCircleIcon fontSize="small" /> : "출석"}
               </Button>
               <Button
                 variant="contained"
                 color="error"
-                startIcon={<CancelIcon />}
+                startIcon={isNarrow ? undefined : <CancelIcon />}
                 onClick={() => handleBulkSave(AttendStatus.ABSENT)}
                 disabled={saving}
                 size="small"
+                title="결석"
+                sx={{ minWidth: { xs: 44, sm: "auto" }, px: { xs: 1, sm: 2 } }}
               >
-                결석
+                {isNarrow ? <CancelIcon fontSize="small" /> : "결석"}
               </Button>
               <Button
                 variant="contained"
                 color="warning"
-                startIcon={<HelpIcon />}
+                startIcon={isNarrow ? undefined : <HelpIcon />}
                 onClick={() => handleBulkSave(AttendStatus.ETC)}
                 disabled={saving}
                 size="small"
+                title="기타"
+                sx={{ minWidth: { xs: 44, sm: "auto" }, px: { xs: 1, sm: 2 } }}
               >
-                기타
+                {isNarrow ? <HelpIcon fontSize="small" /> : "기타"}
               </Button>
               <Button
                 variant="outlined"
                 onClick={() => setCheckedIds(new Set())}
                 disabled={saving}
                 size="small"
+                title="선택 해제"
+                sx={{ minWidth: { xs: 44, sm: "auto" }, px: { xs: 1, sm: 2 } }}
               >
-                해제
+                {isNarrow ? <CloseIcon fontSize="small" /> : "해제"}
               </Button>
             </Stack>
           </Stack>

--- a/client/src/app/admin/soon/attendance/EditTab.tsx
+++ b/client/src/app/admin/soon/attendance/EditTab.tsx
@@ -1,0 +1,1072 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import {
+  Box,
+  Stack,
+  Typography,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  TextField,
+  Checkbox,
+  Button,
+  Chip,
+  Paper,
+  CircularProgress,
+  Snackbar,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  IconButton,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material"
+import ChevronRightIcon from "@mui/icons-material/ChevronRight"
+import ArrowBackIcon from "@mui/icons-material/ArrowBack"
+import CheckCircleIcon from "@mui/icons-material/CheckCircle"
+import CancelIcon from "@mui/icons-material/Cancel"
+import HelpIcon from "@mui/icons-material/Help"
+
+import axios from "@/config/axios"
+import { get } from "@/config/api"
+import { AttendData } from "@server/entity/attendData"
+import { AttendStatus } from "@server/entity/types"
+import { Community } from "@server/entity/community"
+import { User } from "@server/entity/user"
+import { WorshipSchedule } from "@server/entity/worshipSchedule"
+import { worshipKr } from "@/util/worship"
+import { useNotification } from "@/hooks/useNotification"
+
+type StatusFilter = "all" | "unrecorded" | "ATTEND" | "ABSENT" | "ETC"
+
+export default function EditTab() {
+  const [communities, setCommunities] = useState<Community[]>([])
+  const [allUsers, setAllUsers] = useState<User[]>([])
+  const [schedules, setSchedules] = useState<WorshipSchedule[]>([])
+  const [selectedScheduleId, setSelectedScheduleId] = useState<number | "">("")
+  const [attendData, setAttendData] = useState<AttendData[]>([])
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all")
+  const [searchText, setSearchText] = useState("")
+  const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set())
+  const [focusedVillageId, setFocusedVillageId] = useState<number | null>(null)
+  const [focusedDarakId, setFocusedDarakId] = useState<number | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+
+  // Phase 3: Undo 스낵바
+  const [undoAction, setUndoAction] = useState<{
+    userIds: string[]
+    previousStates: Map<string, { status: StatusFilter; memo: string }>
+    newStatus: AttendStatus
+    scheduleId: number
+  } | null>(null)
+
+  // Phase 3: 공통 사유 다이얼로그
+  const [memoDialog, setMemoDialog] = useState<{
+    status: AttendStatus
+    memo: string
+  } | null>(null)
+
+  const { success, error } = useNotification()
+
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"))
+
+  // 초기 로드
+  useEffect(() => {
+    ;(async () => {
+      try {
+        const [commData, schedResp] = await Promise.all([
+          get("/admin/community"),
+          axios.get<WorshipSchedule[]>("/soon/worship-schedule"),
+        ])
+        setCommunities(commData)
+        setSchedules(schedResp.data)
+        if (schedResp.data.length > 0) {
+          setSelectedScheduleId(schedResp.data[0].id)
+        }
+      } catch (e) {
+        error("데이터 로드 실패")
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }, [])
+
+  // 전체 유저 로드
+  useEffect(() => {
+    if (communities.length === 0) return
+    const topIds = communities
+      .filter((c) => !c.parent)
+      .map((c) => c.id)
+      .join(",")
+    if (!topIds) return
+    axios
+      .post<User[]>("/admin/soon/get-soon-list", { ids: topIds })
+      .then((resp) => setAllUsers(resp.data))
+  }, [communities])
+
+  // 선택된 예배의 출석 데이터 로드
+  useEffect(() => {
+    if (allUsers.length === 0 || !selectedScheduleId) return
+    const userIds = allUsers.map((u) => u.id).join(",")
+    axios
+      .post<AttendData[]>("/admin/soon/user-attendance", { ids: userIds })
+      .then((resp) => {
+        const filtered = resp.data.filter(
+          (d) => d.worshipSchedule.id === selectedScheduleId,
+        )
+        setAttendData(filtered)
+      })
+  }, [allUsers, selectedScheduleId])
+
+  // Memos
+  const attendMap = useMemo(() => {
+    const m = new Map<string, AttendData>()
+    attendData.forEach((d) => m.set(d.user.id, d))
+    return m
+  }, [attendData])
+
+  const parentMap = useMemo(() => {
+    const m = new Map<number, number | null>()
+    communities.forEach((c) => m.set(c.id, c.parent?.id ?? null))
+    return m
+  }, [communities])
+
+  const nameMap = useMemo(() => {
+    const m = new Map<number, string>()
+    communities.forEach((c) => m.set(c.id, c.name))
+    return m
+  }, [communities])
+
+  function getUserStatus(userId: string): StatusFilter {
+    const d = attendMap.get(userId)
+    if (!d) return "unrecorded"
+    return d.isAttend as StatusFilter
+  }
+
+  function findVillageId(darakId: number): number {
+    let cur = darakId
+    for (let i = 0; i < 10; i++) {
+      const parent = parentMap.get(cur)
+      if (parent === null || parent === undefined) return cur
+      cur = parent
+    }
+    return cur
+  }
+
+  // 필터링된 유저
+  const filteredUsers = useMemo(() => {
+    return allUsers.filter((u) => {
+      const status = getUserStatus(u.id)
+      if (statusFilter !== "all" && status !== statusFilter) return false
+      if (searchText && !(u.name || "").includes(searchText)) return false
+      return true
+    })
+  }, [allUsers, statusFilter, searchText, attendMap])
+
+  // 마을별 유저 매핑
+  const usersByVillage = useMemo(() => {
+    const m = new Map<number, User[]>()
+    filteredUsers.forEach((u) => {
+      if (!u.community) return
+      const vid = findVillageId(u.community.id)
+      if (!m.has(vid)) m.set(vid, [])
+      m.get(vid)!.push(u)
+    })
+    return m
+  }, [filteredUsers, parentMap])
+
+  // 다락방별 유저 매핑
+  const usersByDarak = useMemo(() => {
+    const m = new Map<number, User[]>()
+    filteredUsers.forEach((u) => {
+      if (!u.community) return
+      if (!m.has(u.community.id)) m.set(u.community.id, [])
+      m.get(u.community.id)!.push(u)
+    })
+    return m
+  }, [filteredUsers])
+
+  // 컬럼 1: 최상위 마을들
+  const villagesCol = useMemo(() => {
+    return communities
+      .filter((c) => !c.parent)
+      .sort((a, b) => a.id - b.id)
+  }, [communities])
+
+  // 컬럼 2: 포커스된 마을의 직계 다락방들
+  const daraksCol = useMemo(() => {
+    if (!focusedVillageId) return []
+    return communities
+      .filter((c) => c.parent?.id === focusedVillageId)
+      .sort((a, b) => a.id - b.id)
+  }, [communities, focusedVillageId])
+
+  // 컬럼 3: 포커스된 다락방의 순원들 (필터링된 것 중)
+  const usersCol = useMemo(() => {
+    if (!focusedDarakId) return []
+    const users = usersByDarak.get(focusedDarakId) || []
+    return [...users].sort((a, b) => {
+      const aLead =
+        a.community?.leader?.id === a.id
+          ? -2
+          : a.community?.deputyLeader?.id === a.id
+            ? -1
+            : 0
+      const bLead =
+        b.community?.leader?.id === b.id
+          ? -2
+          : b.community?.deputyLeader?.id === b.id
+            ? -1
+            : 0
+      if (aLead !== bLead) return aLead - bLead
+      return (a.name || "").localeCompare(b.name || "")
+    })
+  }, [usersByDarak, focusedDarakId])
+
+  // 검색 시 평면 리스트용 (마을 → 다락방 → 이름 순)
+  const searchResultUsers = useMemo(() => {
+    return [...filteredUsers].sort((a, b) => {
+      const aVid = a.community ? findVillageId(a.community.id) : 0
+      const bVid = b.community ? findVillageId(b.community.id) : 0
+      if (aVid !== bVid) return aVid - bVid
+      const aDid = a.community?.id || 0
+      const bDid = b.community?.id || 0
+      if (aDid !== bDid) return aDid - bDid
+      return (a.name || "").localeCompare(b.name || "")
+    })
+  }, [filteredUsers, parentMap])
+
+  // 필터 변경으로 포커스 그룹이 비었을 경우 자동 해제
+  useEffect(() => {
+    if (
+      focusedVillageId &&
+      (usersByVillage.get(focusedVillageId)?.length ?? 0) === 0
+    ) {
+      setFocusedVillageId(null)
+      setFocusedDarakId(null)
+    } else if (
+      focusedDarakId &&
+      (usersByDarak.get(focusedDarakId)?.length ?? 0) === 0
+    ) {
+      setFocusedDarakId(null)
+    }
+  }, [usersByVillage, usersByDarak])
+
+  // 필터 chip 카운트
+  const counts = useMemo(() => {
+    const base = searchText
+      ? allUsers.filter((u) => (u.name || "").includes(searchText))
+      : allUsers
+    const c = { all: base.length, unrecorded: 0, ATTEND: 0, ABSENT: 0, ETC: 0 }
+    base.forEach((u) => {
+      const s = getUserStatus(u.id)
+      if (s === "unrecorded") c.unrecorded++
+      else (c as any)[s]++
+    })
+    return c
+  }, [allUsers, attendMap, searchText])
+
+  // 선택 헬퍼
+  function toggleUser(id: string) {
+    setCheckedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  function getGroupState(users: User[]): "none" | "some" | "all" {
+    if (users.length === 0) return "none"
+    const n = users.filter((u) => checkedIds.has(u.id)).length
+    if (n === 0) return "none"
+    if (n === users.length) return "all"
+    return "some"
+  }
+
+  function toggleGroup(users: User[]) {
+    const state = getGroupState(users)
+    setCheckedIds((prev) => {
+      const next = new Set(prev)
+      if (state === "all") {
+        users.forEach((u) => next.delete(u.id))
+      } else {
+        users.forEach((u) => next.add(u.id))
+      }
+      return next
+    })
+  }
+
+  // Bulk 저장 진입점 — ABSENT/ETC는 사유 다이얼로그 경유
+  function handleBulkSave(status: AttendStatus) {
+    if (!selectedScheduleId) return
+    if (checkedIds.size === 0) return
+
+    if (status === AttendStatus.ABSENT || status === AttendStatus.ETC) {
+      // 공통 사유 다이얼로그 오픈
+      setMemoDialog({ status, memo: "" })
+      return
+    }
+    // ATTEND는 다이얼로그 없이 바로
+    runBulkSave(status, "")
+  }
+
+  async function runBulkSave(status: AttendStatus, memo: string) {
+    if (!selectedScheduleId) return
+    const ids = Array.from(checkedIds)
+    if (ids.length === 0) return
+
+    // Phase 3: 스냅샷 저장 (undo용)
+    const previousStates = new Map<
+      string,
+      { status: StatusFilter; memo: string }
+    >()
+    ids.forEach((userId) => {
+      previousStates.set(userId, {
+        status: getUserStatus(userId),
+        memo: attendMap.get(userId)?.memo || "",
+      })
+    })
+
+    setSaving(true)
+    const results = await Promise.allSettled(
+      ids.map((userId) =>
+        axios.post("/admin/soon/update-attendance", {
+          userId,
+          worshipScheduleId: selectedScheduleId,
+          isAttend: status,
+          memo,
+        }),
+      ),
+    )
+    const successfulIds: string[] = []
+    ids.forEach((id, i) => {
+      if (results[i].status === "fulfilled") successfulIds.push(id)
+    })
+
+    setAttendData((prev) => {
+      const map = new Map(prev.map((d) => [d.user.id, d]))
+      successfulIds.forEach((userId) => {
+        const existing = map.get(userId)
+        if (existing) {
+          map.set(userId, { ...existing, isAttend: status, memo })
+        } else {
+          map.set(userId, {
+            id: "local-" + userId,
+            user: { id: userId } as User,
+            worshipSchedule: {
+              id: Number(selectedScheduleId),
+            } as WorshipSchedule,
+            isAttend: status,
+            memo,
+          } as AttendData)
+        }
+      })
+      return Array.from(map.values())
+    })
+
+    setSaving(false)
+    const failed = ids.length - successfulIds.length
+    if (failed > 0) {
+      error(`${failed}건 저장 실패`)
+    }
+
+    // Phase 3: Undo 액션 준비 (성공한 것만)
+    if (successfulIds.length > 0) {
+      const snapshot = new Map<
+        string,
+        { status: StatusFilter; memo: string }
+      >()
+      successfulIds.forEach((id) => {
+        const prev = previousStates.get(id)
+        if (prev) snapshot.set(id, prev)
+      })
+      setUndoAction({
+        userIds: successfulIds,
+        previousStates: snapshot,
+        newStatus: status,
+        scheduleId: Number(selectedScheduleId),
+      })
+    }
+    setCheckedIds(new Set())
+  }
+
+  // Phase 3: Undo 실행
+  async function handleUndo() {
+    if (!undoAction) return
+    const action = undoAction
+    setUndoAction(null) // 스낵바 먼저 닫기
+
+    const restorable = action.userIds.filter(
+      (id) => action.previousStates.get(id)?.status !== "unrecorded",
+    )
+    const unrecoverable = action.userIds.length - restorable.length
+
+    if (restorable.length === 0) {
+      error("이전 상태가 '기록안됨'이라 복구할 수 없습니다")
+      return
+    }
+
+    const results = await Promise.allSettled(
+      restorable.map((userId) => {
+        const prev = action.previousStates.get(userId)!
+        return axios.post("/admin/soon/update-attendance", {
+          userId,
+          worshipScheduleId: action.scheduleId,
+          isAttend: prev.status,
+          memo: prev.memo,
+        })
+      }),
+    )
+    const successIds = restorable.filter(
+      (_, i) => results[i].status === "fulfilled",
+    )
+
+    // 로컬 상태 복원
+    setAttendData((prev) => {
+      const map = new Map(prev.map((d) => [d.user.id, d]))
+      successIds.forEach((userId) => {
+        const target = action.previousStates.get(userId)!
+        const existing = map.get(userId)
+        if (existing) {
+          map.set(userId, {
+            ...existing,
+            isAttend: target.status as AttendStatus,
+            memo: target.memo,
+          })
+        }
+      })
+      return Array.from(map.values())
+    })
+
+    let msg = `${successIds.length}명 복구됨`
+    if (unrecoverable > 0) msg += ` (${unrecoverable}명은 복구 불가)`
+    success(msg)
+  }
+
+  function statusChip(status: StatusFilter, memo?: string) {
+    if (status === "ATTEND")
+      return (
+        <Chip
+          size="small"
+          label="출석"
+          sx={{ bgcolor: "rgb(184, 248, 93)", fontWeight: 600 }}
+        />
+      )
+    if (status === "ABSENT")
+      return (
+        <Chip
+          size="small"
+          label={memo ? `결석 · ${memo}` : "결석"}
+          sx={{ bgcolor: "rgb(240, 148, 128)", fontWeight: 600 }}
+        />
+      )
+    if (status === "ETC")
+      return (
+        <Chip
+          size="small"
+          label={memo ? `기타 · ${memo}` : "기타"}
+          sx={{ bgcolor: "rgb(253, 241, 113)", fontWeight: 600 }}
+        />
+      )
+    return null
+  }
+
+  const hiddenSelectedCount = useMemo(() => {
+    const visible = new Set(filteredUsers.map((u) => u.id))
+    let count = 0
+    checkedIds.forEach((id) => {
+      if (!visible.has(id)) count++
+    })
+    return count
+  }, [filteredUsers, checkedIds])
+
+  if (loading) {
+    return (
+      <Box p={4} textAlign="center">
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  return (
+    <Box sx={{ p: 2, pb: 12 }}>
+      {/* 예배 선택 */}
+      <Paper sx={{ p: 2, mb: 2 }}>
+        <FormControl fullWidth size="small">
+          <InputLabel>예배</InputLabel>
+          <Select
+            value={selectedScheduleId}
+            label="예배"
+            onChange={(e) => setSelectedScheduleId(e.target.value as number)}
+          >
+            {schedules.map((s) => (
+              <MenuItem key={s.id} value={s.id}>
+                {s.date} · {worshipKr(s.kind)}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Paper>
+
+      {/* 상태 필터 */}
+      <Paper sx={{ p: 2, mb: 2 }}>
+        <Typography variant="caption" color="text.secondary">
+          상태별 필터
+        </Typography>
+        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap mt={1}>
+          {(
+            [
+              { k: "all", label: "전체", count: counts.all },
+              { k: "unrecorded", label: "기록안됨", count: counts.unrecorded },
+              { k: "ATTEND", label: "출석", count: counts.ATTEND },
+              { k: "ABSENT", label: "결석", count: counts.ABSENT },
+              { k: "ETC", label: "기타", count: counts.ETC },
+            ] as { k: StatusFilter; label: string; count: number }[]
+          ).map(({ k, label, count }) => (
+            <Chip
+              key={k}
+              label={`${label} · ${count}`}
+              color={statusFilter === k ? "primary" : "default"}
+              variant={statusFilter === k ? "filled" : "outlined"}
+              onClick={() => setStatusFilter(k)}
+              disabled={k !== "all" && count === 0}
+            />
+          ))}
+        </Stack>
+      </Paper>
+
+      {/* 검색 */}
+      <Paper sx={{ p: 2, mb: 2 }}>
+        <TextField
+          fullWidth
+          size="small"
+          placeholder="이름 검색"
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+        />
+      </Paper>
+
+      {/* 3-column 리스트 */}
+      <Paper sx={{ p: 2 }}>
+        {/* 전체 선택 헤더 */}
+        <Stack
+          direction="row"
+          alignItems="center"
+          sx={{ borderBottom: "1px solid #e0e0e0", pb: 1, mb: 1 }}
+        >
+          <Checkbox
+            checked={
+              filteredUsers.length > 0 &&
+              filteredUsers.every((u) => checkedIds.has(u.id))
+            }
+            indeterminate={
+              filteredUsers.some((u) => checkedIds.has(u.id)) &&
+              !filteredUsers.every((u) => checkedIds.has(u.id))
+            }
+            onChange={() => toggleGroup(filteredUsers)}
+            disabled={filteredUsers.length === 0}
+          />
+          <Typography fontWeight="bold">
+            전체 선택 (표시 중 {filteredUsers.length}명)
+          </Typography>
+        </Stack>
+
+        {searchText ? (
+          /* 검색 중: 평면 리스트 */
+          <Box
+            sx={{
+              border: "1px solid #e0e0e0",
+              borderRadius: 1,
+              overflow: "hidden",
+              minHeight: 440,
+              display: "flex",
+              flexDirection: "column",
+            }}
+          >
+            <Box
+              sx={{
+                px: 1.5,
+                py: 1,
+                bgcolor: "#f5f5f5",
+                borderBottom: "1px solid #e0e0e0",
+              }}
+            >
+              <Typography variant="subtitle2" fontWeight="bold">
+                검색 결과 ({searchResultUsers.length}명)
+              </Typography>
+            </Box>
+            <Box sx={{ flex: 1, overflow: "auto", maxHeight: 520 }}>
+              {searchResultUsers.length === 0 ? (
+                <EmptyState>검색 결과가 없습니다</EmptyState>
+              ) : (
+                searchResultUsers.map((u) => {
+                  const status = getUserStatus(u.id)
+                  const memo = attendMap.get(u.id)?.memo
+                  const isLeader = u.community?.leader?.id === u.id
+                  const isDeputy = u.community?.deputyLeader?.id === u.id
+                  const checked = checkedIds.has(u.id)
+                  const vId = u.community
+                    ? findVillageId(u.community.id)
+                    : null
+                  const vName = vId ? nameMap.get(vId) : ""
+                  const dName = u.community
+                    ? nameMap.get(u.community.id)
+                    : ""
+                  return (
+                    <RowButton
+                      key={u.id}
+                      focused={checked}
+                      onClick={() => toggleUser(u.id)}
+                    >
+                      <Checkbox
+                        size="small"
+                        checked={checked}
+                        onClick={(e) => e.stopPropagation()}
+                        onChange={() => toggleUser(u.id)}
+                      />
+                      <Stack flex={1} overflow="hidden">
+                        <Stack
+                          direction="row"
+                          alignItems="center"
+                          spacing={0.5}
+                        >
+                          <Typography noWrap fontWeight={500}>
+                            {u.name}
+                          </Typography>
+                          {(isLeader || isDeputy) && (
+                            <Chip
+                              size="small"
+                              label={isLeader ? "순장" : "부순장"}
+                              sx={{
+                                height: 18,
+                                fontSize: 10,
+                                bgcolor: isLeader ? "#e3f2fd" : "#f3e5f5",
+                              }}
+                            />
+                          )}
+                        </Stack>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          noWrap
+                        >
+                          {vName} › {dName} · {u.yearOfBirth}년생 ·{" "}
+                          {u.gender === "man" ? "남" : "여"}
+                        </Typography>
+                      </Stack>
+                      <Box>{statusChip(status, memo)}</Box>
+                    </RowButton>
+                  )
+                })
+              )}
+            </Box>
+          </Box>
+        ) : (
+          <>
+          {/* 모바일 전용: 뒤로가기 + 경로 */}
+          {isMobile && focusedVillageId != null && (
+            <Stack direction="row" alignItems="center" sx={{ mb: 1, pl: 0.5 }}>
+              <IconButton
+                size="small"
+                onClick={() => {
+                  if (focusedDarakId != null) setFocusedDarakId(null)
+                  else setFocusedVillageId(null)
+                }}
+              >
+                <ArrowBackIcon fontSize="small" />
+              </IconButton>
+              <Typography variant="body2" color="text.secondary">
+                {nameMap.get(focusedVillageId)}
+                {focusedDarakId != null &&
+                  ` › ${nameMap.get(focusedDarakId)}`}
+              </Typography>
+            </Stack>
+          )}
+
+          <Stack
+            direction={{ xs: "column", md: "row" }}
+            gap={1.5}
+            sx={{ minHeight: 440 }}
+          >
+          {/* 컬럼 1: 마을 — 모바일에선 focused 상태일 때 숨김 */}
+          {(!isMobile || focusedVillageId == null) && (
+          <ColumnBox title="마을" flex={1}>
+            {villagesCol.map((v) => {
+              const users = usersByVillage.get(v.id) || []
+              const count = users.length
+              const state = getGroupState(users)
+              const isFocused = focusedVillageId === v.id
+              return (
+                <RowButton
+                  key={v.id}
+                  focused={isFocused}
+                  onClick={() => {
+                    setFocusedVillageId(v.id)
+                    setFocusedDarakId(null)
+                  }}
+                >
+                  <Checkbox
+                    size="small"
+                    checked={state === "all"}
+                    indeterminate={state === "some"}
+                    disabled={count === 0}
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={() => toggleGroup(users)}
+                  />
+                  <Stack flex={1} overflow="hidden">
+                    <Typography noWrap fontWeight={isFocused ? 700 : 500}>
+                      {v.name}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {count}명
+                    </Typography>
+                  </Stack>
+                  <ChevronRightIcon fontSize="small" color="disabled" />
+                </RowButton>
+              )
+            })}
+          </ColumnBox>
+
+          )}
+
+          {/* 컬럼 2: 다락방 — 모바일에선 마을 선택됐고 다락방 미선택일 때만 */}
+          {(!isMobile ||
+            (focusedVillageId != null && focusedDarakId == null)) && (
+          <ColumnBox title="다락방" flex={1}>
+            {!focusedVillageId ? (
+              <EmptyState>마을을 선택하세요</EmptyState>
+            ) : daraksCol.length === 0 ? (
+              <EmptyState>하위 다락방 없음</EmptyState>
+            ) : (
+              daraksCol.map((d) => {
+                const users = usersByDarak.get(d.id) || []
+                const count = users.length
+                const state = getGroupState(users)
+                const isFocused = focusedDarakId === d.id
+                return (
+                  <RowButton
+                    key={d.id}
+                    focused={isFocused}
+                    onClick={() => setFocusedDarakId(d.id)}
+                  >
+                    <Checkbox
+                      size="small"
+                      checked={state === "all"}
+                      indeterminate={state === "some"}
+                      disabled={count === 0}
+                      onClick={(e) => e.stopPropagation()}
+                      onChange={() => toggleGroup(users)}
+                    />
+                    <Stack flex={1} overflow="hidden">
+                      <Typography noWrap fontWeight={isFocused ? 700 : 500}>
+                        {d.name}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {count}명
+                      </Typography>
+                    </Stack>
+                    <ChevronRightIcon fontSize="small" color="disabled" />
+                  </RowButton>
+                )
+              })
+            )}
+          </ColumnBox>
+
+          )}
+
+          {/* 컬럼 3: 순원 — 모바일에선 다락방 선택됐을 때만 */}
+          {(!isMobile || focusedDarakId != null) && (
+          <ColumnBox title="순원" flex={1.4}>
+            {!focusedDarakId ? (
+              <EmptyState>다락방을 선택하세요</EmptyState>
+            ) : usersCol.length === 0 ? (
+              <EmptyState>해당 조건의 순원 없음</EmptyState>
+            ) : (
+              usersCol.map((u) => {
+                const status = getUserStatus(u.id)
+                const memo = attendMap.get(u.id)?.memo
+                const isLeader = u.community?.leader?.id === u.id
+                const isDeputy = u.community?.deputyLeader?.id === u.id
+                const checked = checkedIds.has(u.id)
+                return (
+                  <RowButton
+                    key={u.id}
+                    focused={checked}
+                    onClick={() => toggleUser(u.id)}
+                  >
+                    <Checkbox
+                      size="small"
+                      checked={checked}
+                      onClick={(e) => e.stopPropagation()}
+                      onChange={() => toggleUser(u.id)}
+                    />
+                    <Stack flex={1} overflow="hidden">
+                      <Stack direction="row" alignItems="center" spacing={0.5}>
+                        <Typography noWrap>{u.name}</Typography>
+                        {(isLeader || isDeputy) && (
+                          <Chip
+                            size="small"
+                            label={isLeader ? "순장" : "부순장"}
+                            sx={{
+                              height: 18,
+                              fontSize: 10,
+                              bgcolor: isLeader ? "#e3f2fd" : "#f3e5f5",
+                            }}
+                          />
+                        )}
+                      </Stack>
+                      <Typography variant="caption" color="text.secondary">
+                        {u.yearOfBirth}년생 · {u.gender === "man" ? "남" : "여"}
+                      </Typography>
+                    </Stack>
+                    <Box>{statusChip(status, memo)}</Box>
+                  </RowButton>
+                )
+              })
+            )}
+          </ColumnBox>
+          )}
+          </Stack>
+          </>
+        )}
+      </Paper>
+
+      {/* Phase 3: 공통 사유 다이얼로그 */}
+      <Dialog
+        open={Boolean(memoDialog)}
+        onClose={() => setMemoDialog(null)}
+        fullWidth
+        maxWidth="xs"
+      >
+        <DialogTitle>
+          {memoDialog?.status === AttendStatus.ABSENT ? "결석" : "기타"} 사유
+        </DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary" gutterBottom>
+            {checkedIds.size}명에게 공통으로 적용할 사유 (비워두면 각자 빈칸)
+          </Typography>
+          <TextField
+            autoFocus
+            fullWidth
+            margin="dense"
+            placeholder="예: 가족 행사, 시험 준비 등"
+            value={memoDialog?.memo ?? ""}
+            onChange={(e) =>
+              memoDialog &&
+              setMemoDialog({ ...memoDialog, memo: e.target.value })
+            }
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && memoDialog) {
+                const { status, memo } = memoDialog
+                setMemoDialog(null)
+                runBulkSave(status, memo)
+              }
+            }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setMemoDialog(null)}>취소</Button>
+          <Button
+            variant="contained"
+            onClick={() => {
+              if (!memoDialog) return
+              const { status, memo } = memoDialog
+              setMemoDialog(null)
+              runBulkSave(status, memo)
+            }}
+          >
+            적용
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Phase 3: Undo 스낵바 */}
+      <Snackbar
+        open={Boolean(undoAction)}
+        autoHideDuration={10000}
+        onClose={(_, reason) => {
+          if (reason === "clickaway") return
+          setUndoAction(null)
+        }}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        sx={{ mb: checkedIds.size > 0 ? 10 : 2 }}
+        message={
+          undoAction
+            ? `${undoAction.userIds.length}명에게 '${statusLabel(
+                undoAction.newStatus,
+              )}' 적용됨`
+            : ""
+        }
+        action={
+          <Button color="inherit" size="small" onClick={handleUndo}>
+            실행 취소
+          </Button>
+        }
+      />
+
+      {/* Sticky bulk action bar */}
+      {checkedIds.size > 0 && (
+        <Paper
+          elevation={8}
+          sx={{
+            position: "fixed",
+            bottom: 0,
+            left: 0,
+            right: 0,
+            p: 1.5,
+            zIndex: 100,
+            borderTop: "2px solid #1976d2",
+          }}
+        >
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            spacing={1}
+            alignItems={{ xs: "stretch", sm: "center" }}
+          >
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Typography fontWeight="bold">
+                ✓ {checkedIds.size}명 선택
+              </Typography>
+              {hiddenSelectedCount > 0 && (
+                <Typography color="warning.main" variant="caption">
+                  (화면 밖 {hiddenSelectedCount}명 포함)
+                </Typography>
+              )}
+            </Stack>
+            <Box sx={{ flex: 1 }} />
+            <Stack direction="row" spacing={1}>
+              <Button
+                variant="contained"
+                color="success"
+                startIcon={<CheckCircleIcon />}
+                onClick={() => handleBulkSave(AttendStatus.ATTEND)}
+                disabled={saving}
+                size="small"
+              >
+                출석
+              </Button>
+              <Button
+                variant="contained"
+                color="error"
+                startIcon={<CancelIcon />}
+                onClick={() => handleBulkSave(AttendStatus.ABSENT)}
+                disabled={saving}
+                size="small"
+              >
+                결석
+              </Button>
+              <Button
+                variant="contained"
+                color="warning"
+                startIcon={<HelpIcon />}
+                onClick={() => handleBulkSave(AttendStatus.ETC)}
+                disabled={saving}
+                size="small"
+              >
+                기타
+              </Button>
+              <Button
+                variant="outlined"
+                onClick={() => setCheckedIds(new Set())}
+                disabled={saving}
+                size="small"
+              >
+                해제
+              </Button>
+            </Stack>
+          </Stack>
+        </Paper>
+      )}
+    </Box>
+  )
+}
+
+/* --- 하위 컴포넌트 --- */
+
+function ColumnBox({
+  title,
+  flex,
+  children,
+}: {
+  title: string
+  flex: number
+  children: React.ReactNode
+}) {
+  return (
+    <Box
+      flex={flex}
+      sx={{
+        border: "1px solid #e0e0e0",
+        borderRadius: 1,
+        overflow: "hidden",
+        display: "flex",
+        flexDirection: "column",
+        minWidth: 0,
+      }}
+    >
+      <Box
+        sx={{
+          px: 1.5,
+          py: 1,
+          bgcolor: "#f5f5f5",
+          borderBottom: "1px solid #e0e0e0",
+        }}
+      >
+        <Typography variant="subtitle2" fontWeight="bold">
+          {title}
+        </Typography>
+      </Box>
+      <Box sx={{ flex: 1, overflow: "auto", maxHeight: 520 }}>{children}</Box>
+    </Box>
+  )
+}
+
+function RowButton({
+  focused,
+  onClick,
+  children,
+}: {
+  focused?: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <Stack
+      direction="row"
+      alignItems="center"
+      onClick={onClick}
+      sx={{
+        px: 1,
+        py: 0.5,
+        borderBottom: "1px solid #eee",
+        bgcolor: focused ? "#e3f2fd" : "transparent",
+        cursor: "pointer",
+        "&:hover": {
+          bgcolor: focused ? "#bbdefb" : "#f0f7fc",
+        },
+      }}
+    >
+      {children}
+    </Stack>
+  )
+}
+
+function EmptyState({ children }: { children: React.ReactNode }) {
+  return (
+    <Box p={3} textAlign="center" color="text.secondary">
+      <Typography variant="body2">{children}</Typography>
+    </Box>
+  )
+}
+
+function statusLabel(status: AttendStatus) {
+  if (status === AttendStatus.ATTEND) return "출석"
+  if (status === AttendStatus.ABSENT) return "결석"
+  return "기타"
+}

--- a/client/src/app/admin/soon/attendance/OverviewTab.tsx
+++ b/client/src/app/admin/soon/attendance/OverviewTab.tsx
@@ -16,6 +16,7 @@ import CommunityNavigation from "./CommunityNavigation"
 import { sortByCommunityId, getAttendUserCount } from "./utils/attendanceUtils"
 import { useNotification } from "@/hooks/useNotification"
 import useAuth from "@/hooks/useAuth"
+import { toAttendanceErrorMessage } from "@/util/attendanceError"
 
 export default function OverviewTab() {
   const [communities, setCommunities] = useState<Community[]>([])
@@ -167,8 +168,8 @@ export default function OverviewTab() {
           } as AttendData,
         ]
       })
-    } catch (e: any) {
-      error("저장 실패: " + (e?.response?.data?.error || e?.message || ""))
+    } catch (e) {
+      error(toAttendanceErrorMessage(e))
     }
   }
 

--- a/client/src/app/admin/soon/attendance/OverviewTab.tsx
+++ b/client/src/app/admin/soon/attendance/OverviewTab.tsx
@@ -2,6 +2,7 @@
 
 import axios from "@/config/axios"
 import { get } from "@/config/api"
+import CommunityBox from "./CommunityBox"
 import { User } from "@server/entity/user"
 import { Stack, Box, Card, CardContent, Typography } from "@mui/material"
 import { Community } from "@server/entity/community"
@@ -9,19 +10,14 @@ import { useEffect, useMemo, useState } from "react"
 import { AttendData } from "@server/entity/attendData"
 import { AttendStatus } from "@server/entity/types"
 import { WorshipKind, WorshipSchedule } from "@server/entity/worshipSchedule"
-import AttendanceTable from "@/app/admin/soon/attendance/AttendanceTable"
-import AttendanceFilter from "@/app/admin/soon/attendance/AttendanceFilter"
-import CommunityNavigation from "@/app/admin/soon/attendance/CommunityNavigation"
-import {
-  sortByCommunityId,
-  getAttendUserCount,
-} from "@/app/admin/soon/attendance/utils/attendanceUtils"
-import CommunityBox from "@/app/admin/soon/attendance/CommunityBox"
-import useAuth from "@/hooks/useAuth"
-import { useRouter } from "next/navigation"
+import AttendanceTable from "./AttendanceTable"
+import AttendanceFilter from "./AttendanceFilter"
+import CommunityNavigation from "./CommunityNavigation"
+import { sortByCommunityId, getAttendUserCount } from "./utils/attendanceUtils"
 import { useNotification } from "@/hooks/useNotification"
+import useAuth from "@/hooks/useAuth"
 
-export default function AttendanceAdminPage() {
+export default function OverviewTab() {
   const [communities, setCommunities] = useState<Community[]>([])
   const [selectedCommunity, setSelectedCommunity] = useState<Community | null>(
     null,
@@ -33,9 +29,8 @@ export default function AttendanceAdminPage() {
     WorshipKind | "all"
   >("all")
 
-  const { authUserData } = useAuth()
-  const { push } = useRouter()
   const { error } = useNotification()
+  const { authUserData } = useAuth()
   const editable = Boolean(
     authUserData?.role.Admin ||
       authUserData?.role.VillageLeader ||
@@ -43,14 +38,8 @@ export default function AttendanceAdminPage() {
   )
 
   useEffect(() => {
-    // authUserData가 비동기로 로드되므로 준비될 때까지 판정 보류
-    if (!authUserData) return
     fetchCommunities()
-    if (!authUserData.role.VillageLeader) {
-      error("접근 권한이 없습니다.")
-      push("/leader")
-    }
-  }, [authUserData])
+  }, [])
 
   async function fetchCommunities() {
     const data = await get("/admin/community")
@@ -201,72 +190,62 @@ export default function AttendanceAdminPage() {
   }
 
   return (
-    <Box sx={{ minHeight: "100vh", bgcolor: "#f5f5f5" }}>
-      <Box sx={{ p: 2 }}>
-        {/* 커뮤니티 네비게이션 & 필터 통합 카드 */}
-        <Card sx={{ mb: 3 }}>
-          <CardContent sx={{ py: 2 }}>
-            <Stack spacing={2}>
-              {/* 상단: 네비게이션과 필터 */}
-              <Stack
-                direction={{ xs: "column", md: "row" }}
-                spacing={3}
-                alignItems="center"
-              >
-                <Box sx={{ flex: 1 }}>
-                  <CommunityNavigation
-                    communityStack={communityStack}
-                    handleBackClick={handleBackClick}
-                  />
-                </Box>
-                <Box>
-                  <AttendanceFilter
-                    worshipScheduleFilter={worshipScheduleFilter}
-                    setWorshipScheduleFilter={setWorshipScheduleFilter}
-                  />
-                </Box>
-              </Stack>
-
-              {/* 하단: 다락방 선택 */}
-              {filteredCommunities.length > 0 && (
-                <Box>
-                  <Typography
-                    variant="subtitle1"
-                    fontWeight="bold"
-                    gutterBottom
-                  >
-                    다락방 선택
-                  </Typography>
-                  <Stack direction="row" gap={2} flexWrap="wrap">
-                    {filteredCommunities.map((community) => (
-                      <CommunityBox
-                        key={community.id}
-                        community={community}
-                        setSelectedCommunity={handleCommunityClick}
-                      />
-                    ))}
-                  </Stack>
-                </Box>
-              )}
+    <Box sx={{ p: 2 }}>
+      <Card sx={{ mb: 3 }}>
+        <CardContent sx={{ py: 2 }}>
+          <Stack spacing={2}>
+            <Stack
+              direction={{ xs: "column", md: "row" }}
+              spacing={3}
+              alignItems="center"
+            >
+              <Box sx={{ flex: 1 }}>
+                <CommunityNavigation
+                  communityStack={communityStack}
+                  handleBackClick={handleBackClick}
+                />
+              </Box>
+              <Box>
+                <AttendanceFilter
+                  worshipScheduleFilter={worshipScheduleFilter}
+                  setWorshipScheduleFilter={setWorshipScheduleFilter}
+                />
+              </Box>
             </Stack>
-          </CardContent>
-        </Card>
 
-        {/* 출석 테이블 카드 */}
-        <Card>
-          <CardContent sx={{ p: 0 }}>
-            <AttendanceTable
-              soonList={soonList}
-              attendDataList={attendDataList}
-              worshipScheduleMapList={worshipScheduleMapList}
-              leaders={leaders}
-              getAttendUserCount={getAttendUserCount}
-              editable={editable}
-              onSaveCell={handleSaveCell}
-            />
-          </CardContent>
-        </Card>
-      </Box>
+            {filteredCommunities.length > 0 && (
+              <Box>
+                <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+                  다락방 선택
+                </Typography>
+                <Stack direction="row" gap={2} flexWrap="wrap">
+                  {filteredCommunities.map((community) => (
+                    <CommunityBox
+                      key={community.id}
+                      community={community}
+                      setSelectedCommunity={handleCommunityClick}
+                    />
+                  ))}
+                </Stack>
+              </Box>
+            )}
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent sx={{ p: 0 }}>
+          <AttendanceTable
+            soonList={soonList}
+            attendDataList={attendDataList}
+            worshipScheduleMapList={worshipScheduleMapList}
+            leaders={leaders}
+            getAttendUserCount={getAttendUserCount}
+            editable={editable}
+            onSaveCell={handleSaveCell}
+          />
+        </CardContent>
+      </Card>
     </Box>
   )
 }

--- a/client/src/app/admin/soon/attendance/page.tsx
+++ b/client/src/app/admin/soon/attendance/page.tsx
@@ -1,204 +1,32 @@
 "use client"
 
-import axios from "@/config/axios"
-import { get } from "@/config/api"
-import CommunityBox from "./CommunityBox"
-import { User } from "@server/entity/user"
-import { Stack, Box, Card, CardContent, Typography } from "@mui/material"
-import { Community } from "@server/entity/community"
-import { useEffect, useMemo, useState } from "react"
-import { AttendData } from "@server/entity/attendData"
-import { WorshipKind, WorshipSchedule } from "@server/entity/worshipSchedule"
-import AttendanceTable from "./AttendanceTable"
-import AttendanceFilter from "./AttendanceFilter"
-import CommunityNavigation from "./CommunityNavigation"
-import { sortByCommunityId, getAttendUserCount } from "./utils/attendanceUtils"
+import { useState } from "react"
+import { Box, Tab, Tabs } from "@mui/material"
+import OverviewTab from "./OverviewTab"
+import EditTab from "./EditTab"
 
 export default function AttendanceAdminPage() {
-  const [communities, setCommunities] = useState<Community[]>([])
-  const [selectedCommunity, setSelectedCommunity] = useState<Community | null>(
-    null
-  )
-  const [communityStack, setCommunityStack] = useState<Community[]>([])
-  const [soonList, setSoonList] = useState<User[]>([])
-  const [attendDataList, setAttendDataList] = useState<AttendData[]>([])
-  const [worshipScheduleFilter, setWorshipScheduleFilter] = useState<
-    WorshipKind | "all"
-  >("all")
-
-  useEffect(() => {
-    fetchCommunities()
-  }, [])
-
-  async function fetchCommunities() {
-    const data = await get("/admin/community")
-    setCommunities(data)
-  }
-
-  const filteredCommunities = useMemo(() => {
-    if (!selectedCommunity) {
-      return communities.filter((community) => !community.parent)
-    }
-    return communities.filter((community) => {
-      return community.parent?.id === selectedCommunity.id
-    })
-  }, [communities, selectedCommunity])
-
-  const leaders = useMemo(() => {
-    return soonList.filter((user) => {
-      return (
-        user.community?.leader?.id === user.id ||
-        user.community?.deputyLeader?.id === user.id
-      )
-    })
-  }, [soonList])
-
-  useEffect(() => {
-    if (filteredCommunities.length === 0) {
-      if (!selectedCommunity) {
-        setSoonList([])
-        setAttendDataList([])
-        return
-      }
-      axios
-        .post("/admin/soon/get-soon-list", {
-          ids: selectedCommunity?.id,
-        })
-        .then((response) => {
-          const soonListData = response.data as User[]
-          soonListData.sort(sortByCommunityId)
-          setSoonList(soonListData)
-        })
-      return
-    }
-    axios
-      .post("/admin/soon/get-soon-list", {
-        ids: filteredCommunities.map((community) => community.id).join(","),
-      })
-      .then((response) => {
-        const soonListData = response.data as User[]
-        soonListData.sort(sortByCommunityId)
-        setSoonList(soonListData)
-      })
-  }, [filteredCommunities])
-
-  useEffect(() => {
-    if (soonList.length === 0) return
-    const soonIds = soonList.map((user) => user.id)
-
-    axios
-      .post("/admin/soon/user-attendance", {
-        ids: soonIds.join(","),
-      })
-      .then((response) => {
-        setAttendDataList(response.data)
-      })
-  }, [soonList])
-
-  const worshipScheduleMapList = useMemo(() => {
-    const map: WorshipSchedule[] = []
-    attendDataList.forEach((data) => {
-      const existing = map.find(
-        (worshipSchedule) => worshipSchedule.id === data.worshipSchedule.id
-      )
-      if (existing) {
-        return
-      }
-      if (
-        worshipScheduleFilter !== "all" &&
-        data.worshipSchedule.kind !== worshipScheduleFilter
-      ) {
-        return
-      }
-      map.push(data.worshipSchedule)
-    })
-    return map.sort((a, b) => {
-      return new Date(b.date).getTime() - new Date(a.date).getTime()
-    })
-  }, [attendDataList, worshipScheduleFilter])
-
-  function handleCommunityClick(community: Community) {
-    setSelectedCommunity(community)
-    setCommunityStack((prev) => {
-      const newStack = [...prev, community]
-      return newStack
-    })
-  }
-
-  function handleBackClick() {
-    setCommunityStack((prev) => {
-      const newStack = [...prev]
-      newStack.pop()
-      return newStack
-    })
-    setSelectedCommunity(communityStack[communityStack.length - 2] || null)
-  }
+  const [tab, setTab] = useState(0)
 
   return (
     <Box sx={{ minHeight: "100vh", bgcolor: "#f5f5f5" }}>
-      <Box sx={{ p: 2 }}>
-        {/* 커뮤니티 네비게이션 & 필터 통합 카드 */}
-        <Card sx={{ mb: 3 }}>
-          <CardContent sx={{ py: 2 }}>
-            <Stack spacing={2}>
-              {/* 상단: 네비게이션과 필터 */}
-              <Stack
-                direction={{ xs: "column", md: "row" }}
-                spacing={3}
-                alignItems="center"
-              >
-                <Box sx={{ flex: 1 }}>
-                  <CommunityNavigation
-                    communityStack={communityStack}
-                    handleBackClick={handleBackClick}
-                  />
-                </Box>
-                <Box>
-                  <AttendanceFilter
-                    worshipScheduleFilter={worshipScheduleFilter}
-                    setWorshipScheduleFilter={setWorshipScheduleFilter}
-                  />
-                </Box>
-              </Stack>
-
-              {/* 하단: 다락방 선택 */}
-              {filteredCommunities.length > 0 && (
-                <Box>
-                  <Typography
-                    variant="subtitle1"
-                    fontWeight="bold"
-                    gutterBottom
-                  >
-                    다락방 선택
-                  </Typography>
-                  <Stack direction="row" gap={2} flexWrap="wrap">
-                    {filteredCommunities.map((community) => (
-                      <CommunityBox
-                        key={community.id}
-                        community={community}
-                        setSelectedCommunity={handleCommunityClick}
-                      />
-                    ))}
-                  </Stack>
-                </Box>
-              )}
-            </Stack>
-          </CardContent>
-        </Card>
-
-        {/* 출석 테이블 카드 */}
-        <Card>
-          <CardContent sx={{ p: 0 }}>
-            <AttendanceTable
-              soonList={soonList}
-              attendDataList={attendDataList}
-              worshipScheduleMapList={worshipScheduleMapList}
-              leaders={leaders}
-              getAttendUserCount={getAttendUserCount}
-            />
-          </CardContent>
-        </Card>
+      <Box
+        sx={{
+          bgcolor: "white",
+          borderBottom: "1px solid #e0e0e0",
+          px: 2,
+          position: "sticky",
+          top: 0,
+          zIndex: 10,
+        }}
+      >
+        <Tabs value={tab} onChange={(_, v) => setTab(v)}>
+          <Tab label="조회" />
+          <Tab label="입력" />
+        </Tabs>
       </Box>
+      {tab === 0 && <OverviewTab />}
+      {tab === 1 && <EditTab />}
     </Box>
   )
 }

--- a/client/src/app/leader/all-attendance/page.tsx
+++ b/client/src/app/leader/all-attendance/page.tsx
@@ -7,7 +7,6 @@ import { Stack, Box, Card, CardContent, Typography } from "@mui/material"
 import { Community } from "@server/entity/community"
 import { useEffect, useMemo, useState } from "react"
 import { AttendData } from "@server/entity/attendData"
-import { AttendStatus } from "@server/entity/types"
 import { WorshipKind, WorshipSchedule } from "@server/entity/worshipSchedule"
 import AttendanceTable from "@/app/admin/soon/attendance/AttendanceTable"
 import AttendanceFilter from "@/app/admin/soon/attendance/AttendanceFilter"
@@ -36,9 +35,6 @@ export default function AttendanceAdminPage() {
   const { authUserData } = useAuth()
   const { push } = useRouter()
   const { error } = useNotification()
-  const editable = Boolean(
-    authUserData?.role.Admin || authUserData?.role.VillageLeader,
-  )
 
   useEffect(() => {
     // authUserData가 비동기로 로드되므로 준비될 때까지 판정 보류
@@ -137,50 +133,6 @@ export default function AttendanceAdminPage() {
     })
   }, [attendDataList, worshipScheduleFilter])
 
-  async function handleSaveCell(
-    userId: string,
-    worshipScheduleId: number,
-    status: AttendStatus,
-    memo: string,
-  ) {
-    try {
-      await axios.post("/admin/soon/update-attendance", {
-        userId,
-        worshipScheduleId,
-        isAttend: status,
-        memo,
-      })
-
-      setAttendDataList((prev) => {
-        const idx = prev.findIndex(
-          (d) =>
-            d.user.id === userId && d.worshipSchedule.id === worshipScheduleId,
-        )
-        if (idx >= 0) {
-          const updated = [...prev]
-          updated[idx] = { ...updated[idx], isAttend: status, memo }
-          return updated
-        }
-        const schedule = worshipScheduleMapList.find(
-          (ws) => ws.id === worshipScheduleId,
-        )
-        return [
-          ...prev,
-          {
-            user: { id: userId } as User,
-            worshipSchedule: (schedule ?? {
-              id: worshipScheduleId,
-            }) as WorshipSchedule,
-            isAttend: status,
-            memo,
-          } as AttendData,
-        ]
-      })
-    } catch (e: any) {
-      error("저장 실패: " + (e?.response?.data?.error || e?.message || ""))
-    }
-  }
-
   function handleCommunityClick(community: Community) {
     setSelectedCommunity(community)
     setCommunityStack((prev) => {
@@ -259,8 +211,6 @@ export default function AttendanceAdminPage() {
               worshipScheduleMapList={worshipScheduleMapList}
               leaders={leaders}
               getAttendUserCount={getAttendUserCount}
-              editable={editable}
-              onSaveCell={handleSaveCell}
             />
           </CardContent>
         </Card>

--- a/client/src/app/leader/all-attendance/page.tsx
+++ b/client/src/app/leader/all-attendance/page.tsx
@@ -39,11 +39,12 @@ export default function AttendanceAdminPage() {
   useEffect(() => {
     // authUserData가 비동기로 로드되므로 준비될 때까지 판정 보류
     if (!authUserData) return
-    fetchCommunities()
     if (!authUserData.role.VillageLeader) {
       error("접근 권한이 없습니다.")
       push("/leader")
+      return
     }
+    fetchCommunities()
   }, [authUserData])
 
   async function fetchCommunities() {

--- a/client/src/app/leader/all-attendance/page.tsx
+++ b/client/src/app/leader/all-attendance/page.tsx
@@ -37,9 +37,7 @@ export default function AttendanceAdminPage() {
   const { push } = useRouter()
   const { error } = useNotification()
   const editable = Boolean(
-    authUserData?.role.Admin ||
-      authUserData?.role.VillageLeader ||
-      authUserData?.role.Leader,
+    authUserData?.role.Admin || authUserData?.role.VillageLeader,
   )
 
   useEffect(() => {

--- a/client/src/util/attendanceError.ts
+++ b/client/src/util/attendanceError.ts
@@ -1,3 +1,16 @@
+export type BulkAttendanceStatus = "ok" | "forbidden" | "invalid" | "error"
+
+export type BulkAttendanceResultItem = {
+  index: number
+  userId: string
+  status: BulkAttendanceStatus
+  error?: string
+}
+
+export type BulkAttendanceResponse = {
+  results: BulkAttendanceResultItem[]
+}
+
 const SERVER_ERROR_MAP: Record<string, string> = {
   Unauthorized: "로그인이 필요합니다.",
   Forbidden: "해당 유저의 출석을 편집할 권한이 없습니다.",
@@ -7,9 +20,23 @@ const SERVER_ERROR_MAP: Record<string, string> = {
   "Memo too long": "메모는 500자 이내로 작성해주세요.",
 }
 
+const BULK_STATUS_MAP: Record<BulkAttendanceStatus, string> = {
+  ok: "",
+  forbidden: "해당 유저의 출석을 편집할 권한이 없습니다.",
+  invalid: "잘못된 입력입니다.",
+  error: "저장에 실패했습니다.",
+}
+
 export function toAttendanceErrorMessage(e: unknown): string {
   const err = e as { response?: { data?: { error?: string } } }
   const code = err?.response?.data?.error
   if (code && SERVER_ERROR_MAP[code]) return SERVER_ERROR_MAP[code]
   return "저장에 실패했습니다."
+}
+
+export function toBulkResultMessage(item: BulkAttendanceResultItem): string {
+  if (item.error && SERVER_ERROR_MAP[item.error]) {
+    return SERVER_ERROR_MAP[item.error]
+  }
+  return BULK_STATUS_MAP[item.status] || "저장에 실패했습니다."
 }

--- a/client/src/util/attendanceError.ts
+++ b/client/src/util/attendanceError.ts
@@ -1,0 +1,15 @@
+const SERVER_ERROR_MAP: Record<string, string> = {
+  Unauthorized: "로그인이 필요합니다.",
+  Forbidden: "해당 유저의 출석을 편집할 권한이 없습니다.",
+  "Missing required fields": "필수 정보가 누락되었습니다.",
+  "Invalid isAttend value": "잘못된 출석 값입니다.",
+  "Invalid memo type": "메모 형식이 올바르지 않습니다.",
+  "Memo too long": "메모는 500자 이내로 작성해주세요.",
+}
+
+export function toAttendanceErrorMessage(e: unknown): string {
+  const err = e as { response?: { data?: { error?: string } } }
+  const code = err?.response?.data?.error
+  if (code && SERVER_ERROR_MAP[code]) return SERVER_ERROR_MAP[code]
+  return "저장에 실패했습니다."
+}

--- a/server/src/model/attendance.ts
+++ b/server/src/model/attendance.ts
@@ -1,5 +1,21 @@
 import { jwtPayload } from "../util/type"
+import { Community } from "../entity/community"
 import { communityDatabase, userDatabase } from "./dataSource"
+
+const COMMUNITY_CACHE_TTL_MS = 30_000
+let cachedCommunityMap: Map<number, Community> | null = null
+let cachedAt = 0
+
+async function getCommunityMap(): Promise<Map<number, Community>> {
+  const now = Date.now()
+  if (cachedCommunityMap && now - cachedAt < COMMUNITY_CACHE_TTL_MS) {
+    return cachedCommunityMap
+  }
+  const all = await communityDatabase.find({ relations: { children: true } })
+  cachedCommunityMap = new Map(all.map((c) => [c.id, c]))
+  cachedAt = now
+  return cachedCommunityMap
+}
 
 async function isInSubtree(
   ancestorId: number | undefined,
@@ -8,8 +24,7 @@ async function isInSubtree(
   if (!ancestorId || !targetId) return false
   if (ancestorId === targetId) return true
 
-  const all = await communityDatabase.find({ relations: { children: true } })
-  const byId = new Map(all.map((c) => [c.id, c]))
+  const byId = await getCommunityMap()
   const visited = new Set<number>()
 
   function walk(id: number): boolean {

--- a/server/src/model/attendance.ts
+++ b/server/src/model/attendance.ts
@@ -1,0 +1,47 @@
+import { jwtPayload } from "../util/type"
+import { communityDatabase, userDatabase } from "./dataSource"
+
+async function isInSubtree(
+  ancestorId: number | undefined,
+  targetId: number | undefined,
+): Promise<boolean> {
+  if (!ancestorId || !targetId) return false
+  if (ancestorId === targetId) return true
+
+  const all = await communityDatabase.find({ relations: { children: true } })
+  const byId = new Map(all.map((c) => [c.id, c]))
+  const visited = new Set<number>()
+
+  function walk(id: number): boolean {
+    if (visited.has(id)) return false
+    visited.add(id)
+    if (id === targetId) return true
+    const node = byId.get(id)
+    if (!node) return false
+    return node.children.some((child) => walk(child.id))
+  }
+  return walk(ancestorId)
+}
+
+export async function canEditUserAttendance(
+  requester: jwtPayload,
+  targetUserId: string,
+): Promise<boolean> {
+  if (requester.role.Admin) return true
+
+  const target = await userDatabase.findOne({
+    where: { id: targetUserId },
+    relations: { community: true },
+  })
+  if (!target?.community) return false
+
+  if (requester.role.Leader) {
+    return requester.community?.id === target.community.id
+  }
+
+  if (requester.role.VillageLeader) {
+    return isInSubtree(requester.community?.id, target.community.id)
+  }
+
+  return false
+}

--- a/server/src/routes/admin/soonRouter.ts
+++ b/server/src/routes/admin/soonRouter.ts
@@ -243,7 +243,7 @@ router.post("/update-attendance", async (req, res) => {
 
   const allowed = await canEditUserAttendance(jwt, userId)
   if (!allowed) {
-    res.status(403).send({ error: "해당 유저의 출석을 편집할 권한이 없습니다." })
+    res.status(403).send({ error: "Forbidden" })
     return
   }
 

--- a/server/src/routes/admin/soonRouter.ts
+++ b/server/src/routes/admin/soonRouter.ts
@@ -1,5 +1,5 @@
 import express from "express"
-import { hasPermission } from "../../util/util"
+import { checkJwt, hasPermission } from "../../util/util"
 import { PermissionType } from "../../entity/types"
 import {
   attendDataDatabase,
@@ -8,6 +8,7 @@ import {
 } from "../../model/dataSource"
 import { In, Not, IsNull } from "typeorm"
 import _ from "lodash"
+import { jwtPayload } from "../../util/type"
 
 const router = express.Router()
 
@@ -184,6 +185,92 @@ router.post("/user-attendance", async (req, res) => {
     },
   })
   res.status(200).send(attendDataList)
+})
+
+async function isInSubtree(
+  ancestorId: number | undefined,
+  targetId: number | undefined,
+): Promise<boolean> {
+  if (!ancestorId || !targetId) return false
+  if (ancestorId === targetId) return true
+
+  const all = await communityDatabase.find({ relations: { children: true } })
+  const visited = new Set<number>()
+
+  function walk(id: number): boolean {
+    if (visited.has(id)) return false
+    visited.add(id)
+    if (id === targetId) return true
+    const node = all.find((c) => c.id === id)
+    if (!node) return false
+    return node.children.some((child) => walk(child.id))
+  }
+  return walk(ancestorId)
+}
+
+async function canEditUserAttendance(
+  requester: jwtPayload,
+  targetUserId: string,
+): Promise<boolean> {
+  // Admin은 어느 유저든 편집 가능
+  if (requester.role.Admin) return true
+
+  // 출석 관리 권한이 있는 역할: Leader (자기 다락방) 또는 VillageLeader (마을 트리 하위 전체)
+  if (!requester.role.Leader && !requester.role.VillageLeader) return false
+
+  const target = await userDatabase.findOne({
+    where: { id: targetUserId },
+    relations: { community: true },
+  })
+  if (!target?.community) return false
+
+  // 대상 유저의 community가 내 community의 하위(또는 동일)인지
+  return await isInSubtree(requester.community?.id, target.community.id)
+}
+
+router.post("/update-attendance", async (req, res) => {
+  const jwt = await checkJwt(req)
+  if (!jwt) {
+    res.status(401).send({ error: "Unauthorized" })
+    return
+  }
+
+  const { userId, worshipScheduleId, isAttend, memo } = req.body
+  if (!userId || !worshipScheduleId || !isAttend) {
+    res.status(400).send({ error: "Missing required fields" })
+    return
+  }
+
+  const allowed = await canEditUserAttendance(jwt, userId)
+  if (!allowed) {
+    res.status(403).send({ error: "해당 유저의 출석을 편집할 권한이 없습니다." })
+    return
+  }
+
+  const existing = await attendDataDatabase.findOne({
+    where: {
+      user: { id: userId },
+      worshipSchedule: { id: worshipScheduleId },
+    },
+  })
+
+  if (existing) {
+    existing.isAttend = isAttend
+    existing.memo = memo || ""
+    await attendDataDatabase.save(existing)
+    res.send({ result: "success" })
+    return
+  }
+
+  await attendDataDatabase.save(
+    attendDataDatabase.create({
+      user: { id: userId },
+      worshipSchedule: { id: worshipScheduleId },
+      isAttend,
+      memo: memo || "",
+    }),
+  )
+  res.send({ result: "success" })
 })
 
 export default router

--- a/server/src/routes/admin/soonRouter.ts
+++ b/server/src/routes/admin/soonRouter.ts
@@ -250,4 +250,92 @@ router.post("/update-attendance", async (req, res) => {
   res.send({ result: "success" })
 })
 
+const BULK_MAX_ITEMS = 100
+
+type BulkResult = {
+  index: number
+  userId: string
+  status: "ok" | "forbidden" | "invalid" | "error"
+  error?: string
+}
+
+router.post("/update-attendance-bulk", async (req, res) => {
+  const jwt = await checkJwt(req)
+  if (!jwt) {
+    res.status(401).send({ error: "Unauthorized" })
+    return
+  }
+
+  const { worshipScheduleId, items } = req.body
+  if (!worshipScheduleId) {
+    res.status(400).send({ error: "Missing worshipScheduleId" })
+    return
+  }
+  if (!Array.isArray(items) || items.length === 0) {
+    res.status(400).send({ error: "Missing items" })
+    return
+  }
+  if (items.length > BULK_MAX_ITEMS) {
+    res.status(413).send({ error: "Too many items" })
+    return
+  }
+
+  const results: BulkResult[] = await Promise.all(
+    items.map(async (item, index): Promise<BulkResult> => {
+      const { userId, isAttend, memo } = item ?? {}
+
+      if (!userId || !isAttend) {
+        return { index, userId, status: "invalid", error: "Missing required fields" }
+      }
+      if (!(Object.values(AttendStatus) as string[]).includes(isAttend)) {
+        return { index, userId, status: "invalid", error: "Invalid isAttend value" }
+      }
+      if (memo !== undefined && memo !== null) {
+        if (typeof memo !== "string") {
+          return { index, userId, status: "invalid", error: "Invalid memo type" }
+        }
+        if (memo.length > 500) {
+          return { index, userId, status: "invalid", error: "Memo too long" }
+        }
+      }
+
+      const allowed = await canEditUserAttendance(jwt, userId)
+      if (!allowed) {
+        return { index, userId, status: "forbidden" }
+      }
+
+      try {
+        const existing = await attendDataDatabase.findOne({
+          where: {
+            user: { id: userId },
+            worshipSchedule: { id: worshipScheduleId },
+          },
+        })
+        if (existing) {
+          existing.isAttend = isAttend
+          if (typeof memo === "string") {
+            existing.memo = memo
+          }
+          await attendDataDatabase.save(existing)
+        } else {
+          await attendDataDatabase.save(
+            attendDataDatabase.create({
+              user: { id: userId },
+              worshipSchedule: { id: worshipScheduleId },
+              isAttend,
+              memo: typeof memo === "string" ? memo : "",
+            }),
+          )
+        }
+        return { index, userId, status: "ok" }
+      } catch {
+        return { index, userId, status: "error", error: "Save failed" }
+      }
+    }),
+  )
+
+  const hasFailure = results.some((r) => r.status !== "ok")
+  res.status(hasFailure ? 207 : 200).send({ results })
+})
+
 export default router

--- a/server/src/routes/admin/soonRouter.ts
+++ b/server/src/routes/admin/soonRouter.ts
@@ -1,6 +1,6 @@
 import express from "express"
 import { checkJwt, hasPermission } from "../../util/util"
-import { PermissionType } from "../../entity/types"
+import { AttendStatus, PermissionType } from "../../entity/types"
 import {
   attendDataDatabase,
   communityDatabase,
@@ -239,6 +239,22 @@ router.post("/update-attendance", async (req, res) => {
   if (!userId || !worshipScheduleId || !isAttend) {
     res.status(400).send({ error: "Missing required fields" })
     return
+  }
+
+  if (!(Object.values(AttendStatus) as string[]).includes(isAttend)) {
+    res.status(400).send({ error: "Invalid isAttend value" })
+    return
+  }
+
+  if (memo !== undefined && memo !== null) {
+    if (typeof memo !== "string") {
+      res.status(400).send({ error: "Invalid memo type" })
+      return
+    }
+    if (memo.length > 500) {
+      res.status(400).send({ error: "Memo too long" })
+      return
+    }
   }
 
   const allowed = await canEditUserAttendance(jwt, userId)

--- a/server/src/routes/admin/soonRouter.ts
+++ b/server/src/routes/admin/soonRouter.ts
@@ -6,9 +6,9 @@ import {
   communityDatabase,
   userDatabase,
 } from "../../model/dataSource"
+import { canEditUserAttendance } from "../../model/attendance"
 import { In, Not, IsNull } from "typeorm"
 import _ from "lodash"
-import { jwtPayload } from "../../util/type"
 
 const router = express.Router()
 
@@ -187,47 +187,6 @@ router.post("/user-attendance", async (req, res) => {
   res.status(200).send(attendDataList)
 })
 
-async function isInSubtree(
-  ancestorId: number | undefined,
-  targetId: number | undefined,
-): Promise<boolean> {
-  if (!ancestorId || !targetId) return false
-  if (ancestorId === targetId) return true
-
-  const all = await communityDatabase.find({ relations: { children: true } })
-  const visited = new Set<number>()
-
-  function walk(id: number): boolean {
-    if (visited.has(id)) return false
-    visited.add(id)
-    if (id === targetId) return true
-    const node = all.find((c) => c.id === id)
-    if (!node) return false
-    return node.children.some((child) => walk(child.id))
-  }
-  return walk(ancestorId)
-}
-
-async function canEditUserAttendance(
-  requester: jwtPayload,
-  targetUserId: string,
-): Promise<boolean> {
-  // Admin은 어느 유저든 편집 가능
-  if (requester.role.Admin) return true
-
-  // 출석 관리 권한이 있는 역할: Leader (자기 다락방) 또는 VillageLeader (마을 트리 하위 전체)
-  if (!requester.role.Leader && !requester.role.VillageLeader) return false
-
-  const target = await userDatabase.findOne({
-    where: { id: targetUserId },
-    relations: { community: true },
-  })
-  if (!target?.community) return false
-
-  // 대상 유저의 community가 내 community의 하위(또는 동일)인지
-  return await isInSubtree(requester.community?.id, target.community.id)
-}
-
 router.post("/update-attendance", async (req, res) => {
   const jwt = await checkJwt(req)
   if (!jwt) {
@@ -272,7 +231,9 @@ router.post("/update-attendance", async (req, res) => {
 
   if (existing) {
     existing.isAttend = isAttend
-    existing.memo = memo || ""
+    if (typeof memo === "string") {
+      existing.memo = memo
+    }
     await attendDataDatabase.save(existing)
     res.send({ result: "success" })
     return
@@ -283,7 +244,7 @@ router.post("/update-attendance", async (req, res) => {
       user: { id: userId },
       worshipSchedule: { id: worshipScheduleId },
       isAttend,
-      memo: memo || "",
+      memo: typeof memo === "string" ? memo : "",
     }),
   )
   res.send({ result: "success" })


### PR DESCRIPTION
## Summary
- 마을/다락방 단위로 출석을 **편집**할 수 있는 어드민 탭을 신설하고, 기존 출석 현황은 별도 탭으로 분리했습니다
- 출석 편집 API를 신설(`/update-attendance` 단건 + `/update-attendance-bulk` 일괄)하고 **인가·입력 검증·응답 최소화·207 Multi-Status**를 적용해 보안과 일관성을 강화했습니다
- 모바일 화면에서의 출석 관리 UX를 최적화했습니다

## 주요 변경

### 🆕 기능
- `EditTab` (신규, ~1160줄): 마을 → 다락방 → 순원 3컬럼 뷰에서 개별/일괄 출석 편집, 사유 다이얼로그, Undo 스낵바 지원
- `OverviewTab` (신규, ~251줄): 기존 `page.tsx`의 현황 보기 로직을 독립 탭으로 분리
- `page.tsx`: 두 탭을 스위칭하는 얇은 셸로 축소 (204줄 → 32줄)

### 🔒 보안 / 권한
- 서버 권한 로직을 `server/src/model/attendance.ts`로 분리
- **Leader / VillageLeader 권한 범위 명시적 분기**
  - Leader: 본인 community와 동일한 community만 편집 가능
  - VillageLeader: 본인 community의 subtree 전체
  - Admin: 전권
- `isAttend`/`memo` 입력 검증 (단건·일괄 모두 적용)
- 403 응답 본문 \`"Forbidden"\`으로 단축 (정보 노출 방지)

### ⚡ 성능
- `isInSubtree`: id→node `Map`으로 O(1) 조회 + **30초 모듈 캐시**로 중복 DB 조회 제거
- 일괄 저장: 10개씩 클라이언트 배치 → **단일 서버 bulk endpoint(최대 100건, 207 Multi-Status)** 로 승격
- bulk 응답은 per-item status (`ok` / `forbidden` / `invalid` / `error`)로 부분 실패 명확화

### 📱 UX
- `AttendCell` 모바일 렌더링 개선
- `leader/all-attendance` 페이지 정보 밀도 조정 + 권한 체크 후 fetch (불필요 트래픽 제거)
- 서버 영문 에러 코드 → 한국어 메시지 매핑 유틸(`util/attendanceError.ts`)

## 🔄 Review 반영 (Round 2)
| 코멘트 | 반영 내용 |
|---|---|
| Leader/VillageLeader 범위 분리 | `canEditUserAttendance`에서 role별 분기 |
| `isInSubtree` 성능 | id→node Map + 30초 캐시 |
| 미사용 MUI import | EditTab의 `Select/MenuItem/FormControl/InputLabel` 제거 |
| bulk edit 동시성 | 클라 배치 → **서버 bulk endpoint 도입 (207 Multi-Status)** |
| memo 덮어쓰기 버그 | `if (typeof memo === "string")` 조건부 업데이트 |
| `fetchCommunities` 순서 | 권한 체크 후 호출하도록 early return |
| 라우터 → model 분리 | `server/src/model/attendance.ts` 신설 |
| 에러 메시지 UX | `util/attendanceError.ts` 매핑 유틸 (단건·bulk 통합) |
| "우린 ssg임" | `AttendanceTable` 주석 `SSR-safe → SSG`로 교정 |
| onSave 가독성 | JSX 삼항 → `handleSave` 변수 추출 |
| `"use client"` 누락 경고 (Copilot) | SSG/부모 상속 관례상 false positive로 판정, 원복 |

## Test plan
- [x] 클라이언트 빌드 성공 (`cd client && npm run build`)
- [x] 서버 타입체크 통과 (`cd server && npx tsc --noEmit`)
- [x] 클라이언트 타입체크 통과 (`cd client && npx tsc --noEmit`)
- [ ] 배포 후 Leader 계정으로 자기 community 출석 1건 편집 스모크 테스트
- [ ] 배포 후 VillageLeader 계정으로 subtree 일괄 저장 스모크 테스트
- [ ] 배포 후 403 / 207 응답 비율 모니터링

## 비고
- DB 엔티티 / 마이그레이션 변경 없음
- JWT payload 구조 변경 없음 → 기존 세션 유지
- 신규 의존성 없음

## 후속 검토 (별도 PR 권장)
- 캐시 갱신 single-flight 패턴 (현재는 동시 갱신 시 DB 중복 조회 가능)
- bulk endpoint 동시성 제한 (`pLimit` 등으로 DB connection pool 보호)
- bulk 부분 실패 시 transaction 도입 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)