### PR TITLE
[codex] 주일 주보 및 월기 악보 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 sharing/*
+bulletin/*
 .DS_Store
 **/.DS_Store
 **/pnpm-lock.yaml

--- a/client/src/app/admin/bulletin/page.tsx
+++ b/client/src/app/admin/bulletin/page.tsx
@@ -1,0 +1,293 @@
+"use client"
+
+import DeleteIcon from "@mui/icons-material/Delete"
+import UploadIcon from "@mui/icons-material/Upload"
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  MenuItem,
+  IconButton,
+  TextField,
+  Stack,
+  Typography,
+} from "@mui/material"
+import { useEffect, useState } from "react"
+import axios, { SERVER_FULL_PATH } from "@/config/axios"
+import { useNotification } from "@/hooks/useNotification"
+import type {
+  AdminBulletinResponse,
+  BulletinImageSlot,
+  BulletinWeek,
+} from "@/types/bulletin"
+import { getBulletinWeekTitle } from "@/util/bulletin"
+
+const bulletinImageSlots: BulletinImageSlot[] = [1, 2]
+
+interface UploadingBulletinImage {
+  weekDate: string
+  slot: BulletinImageSlot
+}
+
+function getBulletinImageTitle(slot: BulletinImageSlot) {
+  return slot === 1 ? "첫 번째 주보 이미지" : "두 번째 주보 이미지"
+}
+
+function formatDate(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+function addDays(dateString: string, days: number) {
+  const [year, month, day] = dateString.split("-").map(Number)
+  const date = new Date(year, month - 1, day)
+  date.setDate(date.getDate() + days)
+  return formatDate(date)
+}
+
+function getBulletinDateLabel(weekDate: string) {
+  return new Date(`${weekDate}T00:00:00`).toLocaleDateString("ko-KR", {
+    month: "long",
+    day: "numeric",
+    weekday: "long",
+  })
+}
+
+export default function AdminBulletinPage() {
+  const { success, error } = useNotification()
+  const [bulletinWeeks, setBulletinWeeks] = useState<BulletinWeek[]>([])
+  const [nextWeekDate, setNextWeekDate] = useState("")
+  const [selectedWeekDate, setSelectedWeekDate] = useState("")
+  const [loading, setLoading] = useState(true)
+  const [uploadingImage, setUploadingImage] =
+    useState<UploadingBulletinImage | null>(null)
+
+  const weekDateOptions = Array.from(
+    new Set([
+      ...bulletinWeeks.map((week) => week.weekDate),
+      ...Array.from({ length: 16 }, (_, index) =>
+        nextWeekDate ? addDays(nextWeekDate, (index - 4) * 7) : "",
+      ).filter(Boolean),
+    ]),
+  ).sort((a, b) => a.localeCompare(b))
+  const selectedWeek = bulletinWeeks.find(
+    (week) => week.weekDate === selectedWeekDate,
+  ) || { weekDate: selectedWeekDate, images: [] }
+
+  useEffect(() => {
+    fetchImages()
+  }, [])
+
+  async function fetchImages() {
+    try {
+      setLoading(true)
+      const { data } = await axios.get<AdminBulletinResponse>("/admin/bulletin")
+      setBulletinWeeks(data.weeks)
+      setNextWeekDate(data.nextWeekDate)
+      setSelectedWeekDate((current) => current || data.nextWeekDate)
+    } catch (err) {
+      if (
+        axios.isAxiosError(err) &&
+        (err.response?.status === 401 || err.response?.status === 403)
+      ) {
+        return
+      }
+      error("주보 이미지를 불러올 수 없습니다.")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function uploadImageToSlot(
+    weekDate: string,
+    slot: BulletinImageSlot,
+    file: File | undefined,
+  ) {
+    if (!file) {
+      return
+    }
+
+    try {
+      setUploadingImage({ weekDate, slot })
+      const formData = new FormData()
+      formData.append("image", file)
+      await axios.put(`/admin/bulletin/${weekDate}/${slot}`, formData)
+      await fetchImages()
+      success("주보 이미지가 업로드되었습니다.")
+    } catch (err) {
+      error("주보 이미지 업로드에 실패했습니다.")
+    } finally {
+      setUploadingImage(null)
+    }
+  }
+
+  async function deleteImageFromSlot(weekDate: string, slot: BulletinImageSlot) {
+    if (!confirm("정말 삭제하시겠습니까?")) {
+      return
+    }
+
+    try {
+      await axios.delete(`/admin/bulletin/${weekDate}/${slot}`)
+      await fetchImages()
+      success("주보 이미지가 삭제되었습니다.")
+    } catch (err) {
+      error("주보 이미지 삭제에 실패했습니다.")
+    }
+  }
+
+  return (
+    <Box sx={{ px: { xs: 2, sm: 3 }, py: { xs: 2, sm: 3 } }}>
+      <Stack spacing={2} sx={{ maxWidth: 980, mx: "auto" }}>
+        <Card>
+          <CardContent>
+            <Typography variant="h5" fontWeight={800}>
+              주보 관리
+            </Typography>
+          </CardContent>
+        </Card>
+
+        {loading ? (
+          <Stack alignItems="center" sx={{ py: 8 }}>
+            <CircularProgress />
+          </Stack>
+        ) : (
+          <Stack spacing={2}>
+            <Card>
+              <CardContent>
+                <Stack spacing={2}>
+                  <TextField
+                    select
+                    label="주보 날짜"
+                    value={selectedWeekDate}
+                    onChange={(event) => setSelectedWeekDate(event.target.value)}
+                    sx={{ maxWidth: 320 }}
+                  >
+                    {weekDateOptions.map((weekDate) => (
+                      <MenuItem key={weekDate} value={weekDate}>
+                        {getBulletinDateLabel(weekDate)}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+
+                  <Stack>
+                    <Typography variant="h6" fontWeight={800}>
+                      {getBulletinWeekTitle(selectedWeek.weekDate)}
+                    </Typography>
+                    <Typography color="text.secondary">
+                      {selectedWeek.weekDate}
+                    </Typography>
+                  </Stack>
+
+                  {bulletinImageSlots.map((slot) => {
+                    const bulletinImage = selectedWeek.images.find(
+                      (item) => item.slot === slot,
+                    )
+                    const uploading =
+                      uploadingImage?.weekDate === selectedWeek.weekDate &&
+                      uploadingImage.slot === slot
+
+                    return (
+                      <Stack
+                        key={`${selectedWeek.weekDate}-${slot}`}
+                        direction={{ xs: "column", sm: "row" }}
+                        spacing={2}
+                        alignItems={{ xs: "stretch", sm: "center" }}
+                      >
+                        {bulletinImage ? (
+                          <Box
+                            component="img"
+                            src={`${SERVER_FULL_PATH}/bulletin/image/${bulletinImage.filename}`}
+                            alt={`${getBulletinWeekTitle(selectedWeek.weekDate)} ${getBulletinImageTitle(slot)}`}
+                            sx={{
+                              width: 88,
+                              height: 120,
+                              objectFit: "cover",
+                              borderRadius: 1,
+                              bgcolor: "#f5f5f5",
+                            }}
+                          />
+                        ) : (
+                          <Box
+                            sx={{
+                              width: 88,
+                              height: 120,
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              borderRadius: 1,
+                              bgcolor: "#f5f5f5",
+                            }}
+                          >
+                            <Typography color="text.secondary">미등록</Typography>
+                          </Box>
+                        )}
+
+                        <Stack sx={{ flex: 1, minWidth: 0 }}>
+                          <Typography fontWeight={700}>
+                            {getBulletinImageTitle(slot)}
+                          </Typography>
+                          <Typography color="text.secondary" noWrap>
+                            {uploading
+                              ? "업로드 중..."
+                              : bulletinImage?.originalName ||
+                                "등록된 이미지가 없습니다."}
+                          </Typography>
+                        </Stack>
+
+                        <Stack
+                          direction="row"
+                          spacing={1}
+                          justifyContent={{
+                            xs: "flex-end",
+                            sm: "flex-start",
+                          }}
+                        >
+                          <Button
+                            variant="contained"
+                            component="label"
+                            startIcon={<UploadIcon />}
+                            disabled={uploading}
+                          >
+                            {bulletinImage ? "이미지 교체" : "이미지 업로드"}
+                            <input
+                              hidden
+                              type="file"
+                              accept="image/jpeg,image/png,image/gif,image/webp"
+                              onChange={(event) => {
+                                uploadImageToSlot(
+                                  selectedWeek.weekDate,
+                                  slot,
+                                  event.target.files?.[0],
+                                )
+                                event.target.value = ""
+                              }}
+                            />
+                          </Button>
+                          {bulletinImage && (
+                            <IconButton
+                              color="error"
+                              aria-label={`${getBulletinWeekTitle(selectedWeek.weekDate)} ${getBulletinImageTitle(slot)} 삭제`}
+                              onClick={() =>
+                                deleteImageFromSlot(selectedWeek.weekDate, slot)
+                              }
+                            >
+                              <DeleteIcon />
+                            </IconButton>
+                          )}
+                        </Stack>
+                      </Stack>
+                    )
+                  })}
+                </Stack>
+              </CardContent>
+            </Card>
+          </Stack>
+        )}
+      </Stack>
+    </Box>
+  )
+}

--- a/client/src/app/admin/components/Header/index.tsx
+++ b/client/src/app/admin/components/Header/index.tsx
@@ -11,6 +11,7 @@ import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline"
 import PeopleOutlineOutlinedIcon from "@mui/icons-material/PeopleOutlineOutlined"
 import LinkIcon from "@mui/icons-material/Link"
 import ForumIcon from "@mui/icons-material/Forum"
+import ImageIcon from "@mui/icons-material/Image"
 
 export default function AdminHeader() {
   const { push } = useRouter()
@@ -74,6 +75,12 @@ export default function AdminHeader() {
       title: "권한 관리",
       icon: <PeopleOutlineOutlinedIcon fontSize="small" />,
       path: "/admin/permission",
+      type: "menu",
+    },
+    {
+      title: "주보 관리",
+      icon: <ImageIcon fontSize="small" />,
+      path: "/admin/bulletin",
       type: "menu",
     },
     {

--- a/client/src/app/bulletin/page.tsx
+++ b/client/src/app/bulletin/page.tsx
@@ -1,0 +1,175 @@
+"use client"
+
+import ArrowBackIcon from "@mui/icons-material/ArrowBack"
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  CircularProgress,
+  IconButton,
+  Stack,
+  Typography,
+} from "@mui/material"
+import { useEffect, useState } from "react"
+import axios, { SERVER_FULL_PATH } from "@/config/axios"
+import type { BulletinWeek } from "@/types/bulletin"
+import { getBulletinWeekTitle } from "@/util/bulletin"
+
+function getCurrentSundayDateString() {
+  const today = new Date()
+  today.setDate(
+    today.getDate() + (today.getDay() === 0 ? 0 : 7 - today.getDay()),
+  )
+  const year = today.getFullYear()
+  const month = String(today.getMonth() + 1).padStart(2, "0")
+  const day = String(today.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+function getDefaultExpandedWeekDate(weeks: BulletinWeek[]) {
+  const currentSunday = getCurrentSundayDateString()
+  return (
+    weeks.find((week) => week.weekDate >= currentSunday)?.weekDate ||
+    weeks.at(-1)?.weekDate ||
+    false
+  )
+}
+
+export default function BulletinPage() {
+  const [bulletinWeeks, setBulletinWeeks] = useState<BulletinWeek[]>([])
+  const [expandedWeekDate, setExpandedWeekDate] = useState<string | false>(
+    false,
+  )
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetchImages()
+  }, [])
+
+  useEffect(() => {
+    if (!expandedWeekDate) {
+      return
+    }
+    const scrollTimer = window.setTimeout(() => {
+      document
+        .getElementById(`bulletin-week-images-${expandedWeekDate}`)
+        ?.scrollIntoView({ block: "start" })
+    }, 250)
+    return () => window.clearTimeout(scrollTimer)
+  }, [expandedWeekDate])
+
+  async function fetchImages() {
+    try {
+      const { data } = await axios.get<BulletinWeek[]>("/bulletin")
+      const weeks = [...data].sort((a, b) =>
+        a.weekDate.localeCompare(b.weekDate),
+      )
+      setBulletinWeeks(weeks)
+      setExpandedWeekDate(getDefaultExpandedWeekDate(weeks))
+    } catch (error) {
+      console.error("Error fetching bulletin weeks:", error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function goBack() {
+    if (window.history.length > 1) {
+      window.history.back()
+      return
+    }
+    window.location.href = "/link/"
+  }
+
+  return (
+    <Box sx={{ minHeight: "100svh", bgcolor: "white" }}>
+      <IconButton
+        aria-label="뒤로 가기"
+        onClick={goBack}
+        sx={{
+          position: "fixed",
+          top: 12,
+          left: 12,
+          zIndex: 9999,
+          color: "#111",
+          bgcolor: "rgba(255,255,255,0.88)",
+          boxShadow: "0 2px 10px rgba(0,0,0,0.14)",
+          "&:hover": {
+            bgcolor: "white",
+          },
+        }}
+      >
+        <ArrowBackIcon />
+      </IconButton>
+
+      {loading ? (
+        <Box
+          sx={{
+            minHeight: "100svh",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <CircularProgress />
+        </Box>
+      ) : bulletinWeeks.length === 0 ? (
+        <Box
+          sx={{
+            minHeight: "100svh",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            px: 2,
+          }}
+        >
+          <Typography color="text.secondary">
+            등록된 주보 이미지가 없습니다.
+          </Typography>
+        </Box>
+      ) : (
+        <Box sx={{ px: { xs: 1.5, sm: 2 }, pt: 7, pb: 3 }}>
+          <Stack spacing={1.5} sx={{ maxWidth: 720, mx: "auto" }}>
+            {bulletinWeeks.map((week) => (
+              <Accordion
+                key={week.weekDate}
+                expanded={expandedWeekDate === week.weekDate}
+                onChange={(_, expanded) =>
+                  setExpandedWeekDate(expanded ? week.weekDate : false)
+                }
+                disableGutters
+              >
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography fontWeight={800}>
+                    {getBulletinWeekTitle(week.weekDate)}
+                  </Typography>
+                </AccordionSummary>
+                <AccordionDetails
+                  id={`bulletin-week-images-${week.weekDate}`}
+                  sx={{ p: 0, scrollMarginTop: 60 }}
+                >
+                  {week.images.map((bulletinImage) => (
+                    <Box
+                      key={`${week.weekDate}-${bulletinImage.slot}`}
+                      component="img"
+                      src={`${SERVER_FULL_PATH}/bulletin/image/${bulletinImage.filename}`}
+                      alt={`${getBulletinWeekTitle(week.weekDate)} ${bulletinImage.slot}`}
+                      sx={{
+                        width: "100%",
+                        height: "auto",
+                        display: "block",
+                        bgcolor: "white",
+                      }}
+                    />
+                  ))}
+                </AccordionDetails>
+              </Accordion>
+            ))}
+          </Stack>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/client/src/app/components/LinkCard.tsx
+++ b/client/src/app/components/LinkCard.tsx
@@ -1,10 +1,10 @@
 import { Box, Card, Typography } from "@mui/material"
 import { OpenInNew as OpenInNewIcon } from "@mui/icons-material"
-import { Link } from "@server/entity/link"
+import type { LinkListItem } from "@/types/link"
 
 interface LinkCardProps {
-  link: Link
-  onClick: (link: Link) => void
+  link: LinkListItem
+  onClick: (link: LinkListItem) => void
 }
 
 export default function LinkCard({ link, onClick }: LinkCardProps) {

--- a/client/src/app/components/LinkDetailModal.tsx
+++ b/client/src/app/components/LinkDetailModal.tsx
@@ -11,13 +11,13 @@ import {
   Close as CloseIcon,
   OpenInNew as OpenInNewIcon,
 } from "@mui/icons-material"
-import { Link } from "@server/entity/link"
+import type { LinkListItem } from "@/types/link"
 
 interface LinkDetailModalProps {
   open: boolean
-  link: Link | null
+  link: LinkListItem | null
   onClose: () => void
-  onOpenLink: (link: Link) => void
+  onOpenLink: (link: LinkListItem) => void
 }
 
 export default function LinkDetailModal({

--- a/client/src/app/link/page.tsx
+++ b/client/src/app/link/page.tsx
@@ -2,15 +2,42 @@
 
 import { Stack, Box, CircularProgress, Typography } from "@mui/material"
 import { useEffect, useState } from "react"
-import axios from "axios"
-import { Link } from "@server/entity/link"
 import LinkCard from "@/app/components/LinkCard"
 import LinkDetailModal from "@/app/components/LinkDetailModal"
+import axios from "@/config/axios"
+import type { Link, LinkListItem } from "@/types/link"
+
+const sundayBulletinLink: LinkListItem = {
+  id: "sunday-bulletin",
+  title: "주일 주보",
+  type: "link",
+  url: "/bulletin/",
+}
+
+function addSundayBulletinLink(links: LinkListItem[]) {
+  const hasSundayBulletin = links.some(
+    (link) => link.title === "주일 주보" || link.url === "/bulletin/",
+  )
+  if (hasSundayBulletin) {
+    return links
+  }
+
+  const monthlySheetMusicIndex = links.findIndex(
+    (link) => link.title === "월기 악보",
+  )
+  const insertAt = monthlySheetMusicIndex < 0 ? 0 : monthlySheetMusicIndex
+
+  return [
+    ...links.slice(0, insertAt),
+    sundayBulletinLink,
+    ...links.slice(insertAt),
+  ]
+}
 
 export default function Index() {
-  const [links, setLinks] = useState<Link[]>([])
+  const [links, setLinks] = useState<LinkListItem[]>([])
   const [loading, setLoading] = useState(true)
-  const [selectedLink, setSelectedLink] = useState<Link | null>(null)
+  const [selectedLink, setSelectedLink] = useState<LinkListItem | null>(null)
   const [openModal, setOpenModal] = useState(false)
 
   useEffect(() => {
@@ -20,11 +47,11 @@ export default function Index() {
   async function fetchLinks() {
     try {
       setLoading(true)
-      const response = await axios.get("/link")
+      const response = await axios.get<Link[]>("/link")
       const sortedLinks = response.data.sort(
         (a: Link, b: Link) => a.displayOrder - b.displayOrder,
       )
-      setLinks(sortedLinks)
+      setLinks(addSundayBulletinLink(sortedLinks))
     } catch (error) {
       console.error("Error fetching links:", error)
     } finally {
@@ -32,15 +59,29 @@ export default function Index() {
     }
   }
 
-  async function handleCardClick(link: Link) {
+  function openLink(link: LinkListItem) {
+    if (!link.url) {
+      return
+    }
+    if (link.url.startsWith("/")) {
+      window.location.href = link.url
+      return
+    }
+    window.open(link.url, "_blank", "noopener,noreferrer")
+  }
+
+  async function handleCardClick(link: LinkListItem) {
     if (link.type === "link" && link.url) {
-      window.open(link.url, "_blank")
+      openLink(link)
     } else {
       setSelectedLink(link)
       setOpenModal(true)
     }
 
     // 링크 클릭 기록
+    if (link.id === sundayBulletinLink.id) {
+      return
+    }
     try {
       await axios.post(`/link/${link.id}/click`, {
         userAgent: navigator.userAgent,
@@ -50,9 +91,9 @@ export default function Index() {
     }
   }
 
-  async function handleOpenLink(link: Link) {
+  async function handleOpenLink(link: LinkListItem) {
     if (link.type === "link" && link.url) {
-      window.open(link.url, "_blank")
+      openLink(link)
     }
   }
 

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -28,6 +28,13 @@ export default function Header() {
 
   const DrawerItems: Array<DrawerItemsType> = []
 
+  DrawerItems.push({
+    title: "주일 주보",
+    icon: <EventNoteIcon fontSize="small" sx={{ color: "#667eea" }} />,
+    path: "/bulletin/",
+    type: "menu",
+  })
+
   if (isLogin) {
     DrawerItems.push({
       title: "나의 정보 수정",

--- a/client/src/types/bulletin.ts
+++ b/client/src/types/bulletin.ts
@@ -1,0 +1,20 @@
+export type BulletinImageSlot = 1 | 2
+
+export interface BulletinImage {
+  weekDate: string
+  slot: BulletinImageSlot
+  filename: string
+  originalName: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface BulletinWeek {
+  weekDate: string
+  images: BulletinImage[]
+}
+
+export interface AdminBulletinResponse {
+  weeks: BulletinWeek[]
+  nextWeekDate: string
+}

--- a/client/src/types/link.ts
+++ b/client/src/types/link.ts
@@ -11,3 +11,5 @@ export interface Link {
   createdAt?: string
   updatedAt?: string
 }
+
+export type LinkListItem = Pick<Link, "id" | "title" | "type" | "url" | "body">

--- a/client/src/util/bulletin.ts
+++ b/client/src/util/bulletin.ts
@@ -1,0 +1,18 @@
+const weekNames = ["", "첫째", "둘째", "셋째", "넷째", "다섯째"]
+
+export function getBulletinWeekTitle(weekDate: string) {
+  const [year, month, day] = weekDate.split("-").map(Number)
+  if (!year || !month || !day) {
+    return `${weekDate} 주일 주보`
+  }
+
+  let sundayCount = 0
+  for (let currentDay = 1; currentDay <= day; currentDay += 1) {
+    if (new Date(year, month - 1, currentDay).getDay() === 0) {
+      sundayCount += 1
+    }
+  }
+
+  const weekName = weekNames[sundayCount] || `${sundayCount}번째`
+  return `${month}월 ${weekName}주 주일 주보`
+}

--- a/server/src/entity/bulletinImage.ts
+++ b/server/src/entity/bulletinImage.ts
@@ -1,0 +1,35 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from "typeorm"
+
+@Entity()
+export class BulletinImage {
+  @PrimaryColumn({ type: "date" })
+  weekDate!: string
+
+  @PrimaryColumn({ type: "int" })
+  slot!: number
+
+  @Column({ unique: true })
+  filename!: string
+
+  @Column()
+  originalName!: string
+
+  @CreateDateColumn({
+    type: "timestamp",
+    default: () => "CURRENT_TIMESTAMP(6)",
+  })
+  createdAt!: Date
+
+  @UpdateDateColumn({
+    type: "timestamp",
+    default: () => "CURRENT_TIMESTAMP(6)",
+    onUpdate: "CURRENT_TIMESTAMP(6)",
+  })
+  updatedAt!: Date
+}

--- a/server/src/migration/1782521200000-CreateBulletinImage.ts
+++ b/server/src/migration/1782521200000-CreateBulletinImage.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class CreateBulletinImage1782521200000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            CREATE TABLE \`bulletin_image\` (
+                \`slot\` int NOT NULL,
+                \`filename\` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+                \`originalName\` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+                \`createdAt\` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                \`updatedAt\` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (\`slot\`),
+                UNIQUE INDEX \`UQ_bulletin_image_filename\` (\`filename\`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
+        `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS \`bulletin_image\``)
+  }
+}

--- a/server/src/migration/1782700000000-AddMonthlySheetMusicLink.ts
+++ b/server/src/migration/1782700000000-AddMonthlySheetMusicLink.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+const monthlySheetMusicLinkId = "6f02cba7-3f74-4c4b-9ce7-9f51149d49d2"
+
+export class AddMonthlySheetMusicLink1782700000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      INSERT INTO \`link\` (
+        \`id\`,
+        \`title\`,
+        \`type\`,
+        \`url\`,
+        \`displayOrder\`,
+        \`isActive\`
+      )
+      SELECT
+        '${monthlySheetMusicLinkId}',
+        '월기 악보',
+        'link',
+        'https://m.site.naver.com/14Nhc',
+        linkOrder.nextDisplayOrder,
+        true
+      FROM (
+        SELECT COALESCE(MAX(\`displayOrder\`), 0) + 1 AS nextDisplayOrder
+        FROM \`link\`
+      ) AS linkOrder
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM \`link\`
+        WHERE \`id\` = '${monthlySheetMusicLinkId}'
+          OR \`title\` = '월기 악보'
+          OR \`url\` = 'https://m.site.naver.com/14Nhc'
+      )
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM \`link\`
+      WHERE \`id\` = '${monthlySheetMusicLinkId}'
+    `)
+  }
+}

--- a/server/src/migration/1782800000000-AddBulletinWeekDate.ts
+++ b/server/src/migration/1782800000000-AddBulletinWeekDate.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddBulletinWeekDate1782800000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    if (!(await queryRunner.hasColumn("bulletin_image", "weekDate"))) {
+      await queryRunner.query(`
+        ALTER TABLE \`bulletin_image\`
+        ADD COLUMN \`weekDate\` date NULL FIRST
+      `)
+    }
+    await queryRunner.query(`
+      SET @bulletinToday = DATE(DATE_ADD(UTC_TIMESTAMP(), INTERVAL 9 HOUR))
+    `)
+    await queryRunner.query(`
+      UPDATE \`bulletin_image\`
+      SET \`weekDate\` = DATE_ADD(
+        @bulletinToday,
+        INTERVAL IF(DAYOFWEEK(@bulletinToday) = 1, 0, 8 - DAYOFWEEK(@bulletinToday)) DAY
+      )
+      WHERE \`weekDate\` IS NULL
+    `)
+    await queryRunner.query(`
+      ALTER TABLE \`bulletin_image\`
+      DROP PRIMARY KEY,
+      MODIFY \`weekDate\` date NOT NULL,
+      ADD PRIMARY KEY (\`weekDate\`, \`slot\`)
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    throw new Error(
+      "Cannot safely revert AddBulletinWeekDate because it would merge weekly bulletin rows.",
+    )
+  }
+}

--- a/server/src/model/bulletin.ts
+++ b/server/src/model/bulletin.ts
@@ -1,0 +1,135 @@
+import { bulletinImageDatabase } from "./dataSource"
+import type { BulletinImage } from "../entity/bulletinImage"
+
+export const BULLETIN_IMAGE_SLOTS = [1, 2] as const
+export type BulletinImageSlot = (typeof BULLETIN_IMAGE_SLOTS)[number]
+
+export interface BulletinWeek {
+  weekDate: string
+  images: BulletinImage[]
+}
+
+export function isBulletinImageSlot(value: number): value is BulletinImageSlot {
+  return BULLETIN_IMAGE_SLOTS.includes(value as BulletinImageSlot)
+}
+
+export function isSundayDateString(value: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false
+  }
+
+  const [year, month, day] = value.split("-").map(Number)
+  const date = new Date(year, month - 1, day)
+
+  return (
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day &&
+    date.getDay() === 0
+  )
+}
+
+function getKoreaToday() {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date())
+
+  const year = Number(parts.find((part) => part.type === "year")?.value)
+  const month = Number(parts.find((part) => part.type === "month")?.value)
+  const day = Number(parts.find((part) => part.type === "day")?.value)
+
+  return new Date(year, month - 1, day)
+}
+
+function formatDate(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+function normalizeDate(value: string | Date) {
+  return value instanceof Date ? formatDate(value) : value.slice(0, 10)
+}
+
+export function getNextSundayDateString() {
+  const today = getKoreaToday()
+  const daysUntilNextSunday = today.getDay() === 0 ? 0 : 7 - today.getDay()
+  const nextSunday = new Date(today)
+  nextSunday.setDate(today.getDate() + daysUntilNextSunday)
+  return formatDate(nextSunday)
+}
+
+function groupByWeek(images: BulletinImage[]): BulletinWeek[] {
+  const weeks = new Map<string, BulletinWeek>()
+
+  for (const image of images) {
+    const weekDate = normalizeDate(image.weekDate)
+    const normalizedImage = { ...image, weekDate }
+    const week = weeks.get(weekDate) || {
+      weekDate,
+      images: [],
+    }
+    week.images.push(normalizedImage)
+    weeks.set(weekDate, week)
+  }
+
+  return Array.from(weeks.values())
+}
+
+async function getWeeks() {
+  const images = await bulletinImageDatabase.find({
+    order: {
+      weekDate: "DESC",
+      slot: "ASC",
+    },
+  })
+  return groupByWeek(images)
+}
+
+const BulletinImageModel = {
+  async getPublicWeeks() {
+    return getWeeks()
+  },
+
+  async getAdminWeeks() {
+    return getWeeks()
+  },
+
+  async saveImageInSlot(
+    weekDate: string,
+    slot: BulletinImageSlot,
+    filename: string,
+    originalName: string,
+  ) {
+    const previousBulletinImage = await bulletinImageDatabase.findOne({
+      where: { weekDate, slot },
+    })
+    const bulletinImage = bulletinImageDatabase.create({
+      weekDate,
+      slot,
+      filename,
+      originalName,
+    })
+    return {
+      bulletinImage: await bulletinImageDatabase.save(bulletinImage),
+      previousFilename: previousBulletinImage?.filename,
+    }
+  },
+
+  async deleteImageBySlot(weekDate: string, slot: BulletinImageSlot) {
+    const bulletinImage = await bulletinImageDatabase.findOne({
+      where: { weekDate, slot },
+    })
+    if (!bulletinImage) {
+      return null
+    }
+    await bulletinImageDatabase.delete({ weekDate, slot })
+    return bulletinImage
+  },
+}
+
+export default BulletinImageModel

--- a/server/src/model/dataSource.ts
+++ b/server/src/model/dataSource.ts
@@ -17,6 +17,7 @@ import { NewcomerEducation } from "../entity/newcomer/newcomerEducation"
 import { NewcomerManager } from "../entity/newcomer/newcomerManager"
 import { Link } from "../entity/link"
 import { LinkClick } from "../entity/linkClick"
+import { BulletinImage } from "../entity/bulletinImage"
 import { Post } from "../entity/community/post"
 import { QnaPost } from "../entity/community/qnaPost"
 import { Comment } from "../entity/community/comment"
@@ -46,6 +47,7 @@ export const newcomerManagerDatabase = dataSource.getRepository(NewcomerManager)
 
 export const linkDatabase = dataSource.getRepository(Link)
 export const linkClickDatabase = dataSource.getRepository(LinkClick)
+export const bulletinImageDatabase = dataSource.getRepository(BulletinImage)
 
 export const qnaPostDatabase = dataSource.getRepository(QnaPost)
 export const postDatabase = dataSource.getRepository(Post)

--- a/server/src/routes/admin/adminRouter.ts
+++ b/server/src/routes/admin/adminRouter.ts
@@ -4,6 +4,7 @@ import soonRouter from "./soonRouter"
 import worshipScheduleRouter from "./worshipSchedule"
 import dashboard from "./dashboard"
 import permissionRouter from "./permissionRouter"
+import { adminBulletinRouter } from "../bulletin"
 
 const router = express.Router()
 
@@ -12,5 +13,6 @@ router.use("/soon", soonRouter)
 router.use("/worship-schedule", worshipScheduleRouter)
 router.use("/dashboard", dashboard)
 router.use("/permission", permissionRouter)
+router.use("/bulletin", adminBulletinRouter)
 
 export default router

--- a/server/src/routes/bulletin.ts
+++ b/server/src/routes/bulletin.ts
@@ -1,0 +1,231 @@
+import crypto from "crypto"
+import express, { Router } from "express"
+import fs from "fs"
+import multer from "multer"
+import path from "path"
+import { PermissionType } from "../entity/types"
+import BulletinImageModel, {
+  getNextSundayDateString,
+  isBulletinImageSlot,
+  isSundayDateString,
+} from "../model/bulletin"
+import type { BulletinImageSlot } from "../model/bulletin"
+import { getUserFromToken, hasPermissionFromReq } from "../util/util"
+
+const router: Router = express.Router()
+export const adminBulletinRouter: Router = express.Router()
+
+export const bulletinImagePath = path.resolve(__dirname, "../../../bulletin/image")
+const maxBulletinImageSize = 10 * 1024 * 1024
+const bulletinImageExtensions = {
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+} as const
+
+function getBulletinImageExtension(mimetype: string) {
+  return bulletinImageExtensions[
+    mimetype as keyof typeof bulletinImageExtensions
+  ]
+}
+
+async function isValidBulletinImageFile(file: Express.Multer.File) {
+  const buffer = await fs.promises.readFile(file.path)
+  const asciiHeader = buffer.subarray(0, 12).toString("ascii")
+
+  return (
+    (file.mimetype === "image/jpeg" &&
+      buffer.subarray(0, 3).equals(Buffer.from([0xff, 0xd8, 0xff]))) ||
+    (file.mimetype === "image/png" &&
+      buffer
+        .subarray(0, 8)
+        .equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) ||
+    (file.mimetype === "image/gif" &&
+      (asciiHeader.startsWith("GIF87a") || asciiHeader.startsWith("GIF89a"))) ||
+    (file.mimetype === "image/webp" &&
+      asciiHeader.startsWith("RIFF") &&
+      asciiHeader.slice(8, 12) === "WEBP")
+  )
+}
+
+const uploadBulletinImage = multer({
+  storage: multer.diskStorage({
+    destination: (req, file, callback) => {
+      fs.mkdir(bulletinImagePath, { recursive: true }, (error) => {
+        callback(error, bulletinImagePath)
+      })
+    },
+    filename: (req, file, callback) => {
+      callback(
+        null,
+        `${Date.now()}-${crypto.randomUUID()}${getBulletinImageExtension(file.mimetype)}`,
+      )
+    },
+  }),
+  limits: {
+    fileSize: maxBulletinImageSize,
+  },
+  fileFilter: (req, file, callback) => {
+    callback(null, Boolean(getBulletinImageExtension(file.mimetype)))
+  },
+})
+
+function getBulletinImageSlot(value: string): BulletinImageSlot | null {
+  const slot = Number(value)
+  if (!Number.isInteger(slot) || !isBulletinImageSlot(slot)) {
+    return null
+  }
+  return slot
+}
+
+function getBulletinWeekDate(value: string) {
+  return isSundayDateString(value) ? value : null
+}
+
+function removeBulletinImageFile(filename?: string) {
+  if (!filename) {
+    return
+  }
+  fs.unlink(path.join(bulletinImagePath, filename), () => {})
+}
+
+router.get("/", async (req, res) => {
+  try {
+    const bulletinWeeks = await BulletinImageModel.getPublicWeeks()
+    res.status(200).json(bulletinWeeks)
+  } catch (error) {
+    console.error("Error fetching bulletin weeks:", error)
+    res.status(500).json({ error: "Failed to fetch bulletin weeks" })
+  }
+})
+
+adminBulletinRouter.get("/", async (req, res) => {
+  try {
+    const user = await getUserFromToken(req)
+    if (!user) {
+      res.status(401).json({ error: "Unauthorized" })
+      return
+    }
+
+    const isAdmin = await hasPermissionFromReq(req, PermissionType.admin)
+    if (!isAdmin) {
+      res.status(403).json({ error: "Forbidden" })
+      return
+    }
+
+    const bulletinWeeks = await BulletinImageModel.getAdminWeeks()
+    res.status(200).json({
+      weeks: bulletinWeeks,
+      nextWeekDate: getNextSundayDateString(),
+    })
+  } catch (error) {
+    console.error("Error fetching admin bulletin weeks:", error)
+    res.status(500).json({ error: "Failed to fetch bulletin weeks" })
+  }
+})
+
+adminBulletinRouter.put("/:weekDate/:slot", async (req, res) => {
+  const weekDate = getBulletinWeekDate(req.params.weekDate)
+  if (!weekDate) {
+    res.status(400).json({ error: "Invalid bulletin week date" })
+    return
+  }
+
+  const imageSlot = getBulletinImageSlot(req.params.slot)
+  if (!imageSlot) {
+    res.status(400).json({ error: "Invalid bulletin image slot" })
+    return
+  }
+
+  const user = await getUserFromToken(req)
+  if (!user) {
+    res.status(401).json({ error: "Unauthorized" })
+    return
+  }
+
+  const isAdmin = await hasPermissionFromReq(req, PermissionType.admin)
+  if (!isAdmin) {
+    res.status(403).json({ error: "Forbidden" })
+    return
+  }
+
+  uploadBulletinImage.single("image")(req, res, async (error) => {
+    try {
+      if (error) {
+        res.status(400).json({ error: "Failed to upload image" })
+        return
+      }
+      if (!req.file) {
+        res.status(400).json({ error: "Image file is required" })
+        return
+      }
+      if (!(await isValidBulletinImageFile(req.file))) {
+        removeBulletinImageFile(req.file.filename)
+        res.status(400).json({ error: "Invalid image file" })
+        return
+      }
+
+      const { bulletinImage, previousFilename } =
+        await BulletinImageModel.saveImageInSlot(
+          weekDate,
+          imageSlot,
+          req.file.filename,
+          req.file.originalname,
+        )
+      if (previousFilename && previousFilename !== req.file.filename) {
+        removeBulletinImageFile(previousFilename)
+      }
+      res.status(previousFilename ? 200 : 201).json(bulletinImage)
+    } catch (error) {
+      removeBulletinImageFile(req.file?.filename)
+      console.error("Error creating bulletin image:", error)
+      res.status(500).json({ error: "Failed to create bulletin image" })
+    }
+  })
+})
+
+adminBulletinRouter.delete("/:weekDate/:slot", async (req, res) => {
+  try {
+    const weekDate = getBulletinWeekDate(req.params.weekDate)
+    if (!weekDate) {
+      res.status(400).json({ error: "Invalid bulletin week date" })
+      return
+    }
+
+    const imageSlot = getBulletinImageSlot(req.params.slot)
+    if (!imageSlot) {
+      res.status(400).json({ error: "Invalid bulletin image slot" })
+      return
+    }
+
+    const user = await getUserFromToken(req)
+    if (!user) {
+      res.status(401).json({ error: "Unauthorized" })
+      return
+    }
+
+    const isAdmin = await hasPermissionFromReq(req, PermissionType.admin)
+    if (!isAdmin) {
+      res.status(403).json({ error: "Forbidden" })
+      return
+    }
+
+    const bulletinImage = await BulletinImageModel.deleteImageBySlot(
+      weekDate,
+      imageSlot,
+    )
+    if (!bulletinImage) {
+      res.status(404).json({ error: "Image not found" })
+      return
+    }
+
+    removeBulletinImageFile(bulletinImage.filename)
+    res.status(200).json({ message: "Image deleted successfully" })
+  } catch (error) {
+    console.error("Error deleting bulletin image:", error)
+    res.status(500).json({ error: "Failed to delete bulletin image" })
+  }
+})
+
+export default router

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -11,10 +11,12 @@ import newcomerRouter from "./newcomer/newcomerRouter"
 import eventRouter from "./event"
 import linkRouter from "./link"
 import communityRouter from "./communityRouter"
+import bulletinRouter, { bulletinImagePath } from "./bulletin"
 
 const router: Router = express.Router()
 
 router.use("/sharing/image", express.static(sharingVideoPath))
+router.use("/bulletin/image", express.static(bulletinImagePath))
 
 router.use("/auth", authRouter)
 router.use("/admin", adminRouter)
@@ -26,6 +28,7 @@ router.use("/newcomer", newcomerRouter)
 
 router.use("/event", eventRouter)
 router.use("/link", linkRouter)
+router.use("/bulletin", bulletinRouter)
 router.use("/community", communityRouter)
 
 export default router


### PR DESCRIPTION
## 변경 사항
- 홈 링크에 주일 주보와 월기 악보 항목을 추가했습니다.
- 관리자가 주보 이미지를 2개 슬롯에 업로드/교체/삭제할 수 있는 화면과 API를 추가했습니다.
- 사용자가 주일 주보 이미지를 모바일 화면에서 볼 수 있는 페이지를 추가했습니다.
- 월기 악보 링크를 기존 링크 데이터에 migration으로 추가했습니다.

## 검증
- 로컬 관리자 페이지에서 주보 슬롯 2개와 이미지 표시 확인
- 로컬 dawndew 링크 화면에서 `주일 주보`, `월기 악보` 표시 확인
- `git diff --check origin/main..HEAD` 통과
